### PR TITLE
crashing when exclusive lock to queue is not possible

### DIFF
--- a/dripline/core/service.py
+++ b/dripline/core/service.py
@@ -199,8 +199,10 @@ class Service(Provider):
         :param str reply_text: The text reason the channel was closed
 
         """
-        logger.warning('Channel {} was closed: ({}) {}'.format(
-                       int(channel), reply_code, reply_text))
+        if reply_code == 405:
+            logger.error('crashing because unable to obtain exclusive lock')
+            raise exceptions.DriplineAMQPError(reply_text)
+        logger.warning('Channel {} was closed: ({}) {}'.format( int(channel), reply_code, reply_text))
         self._connection.close()
 
     def setup_exchange(self, exchange_name):


### PR DESCRIPTION
raise an exception and crash if unable to obtain an exclusive queue lock.