### PR TITLE
updated binding code for message and its derived classes

### DIFF
--- a/module_bindings/dripline_cpp/constants/DriplineCppConstants.hh
+++ b/module_bindings/dripline_cpp/constants/DriplineCppConstants.hh
@@ -20,8 +20,6 @@ namespace dripline_cpp_pybind
 
         mod.def("to_uint", (uint32_t (*)(dripline::op_t))&dripline::to_uint, "Convert an op_t to int");
         mod.def("to_op_t", (dripline::op_t (*)(uint32_t))&dripline::to_op_t, "Convert an uint to op_t");
-        // originally operator << - need a better one
-        mod.def("op_t_ostream", [](std::ostream& a_os, dripline::op_t an_op) { a_os << an_op; });
         mod.def("to_string", &dripline::to_string, "Convert an op_t to string");
         mod.def("to_op_t", (dripline::op_t (*)(std::string))&dripline::to_op_t, "Convert an string to op_t");
 
@@ -34,8 +32,8 @@ namespace dripline_cpp_pybind
 
         mod.def("to_uint", (uint32_t (*)(dripline::msg_t))&dripline::to_uint, "Convert a msg_t to int");
         mod.def("to_msg_t", &dripline::to_msg_t, "Convert an uint to msg_t");
-        // originally operator << - need a better one
-        mod.def("msg_t_ostream", [](std::ostream& a_os, dripline::msg_t a_msg) { a_os << a_msg; });
+
+        // operator << ?
 
     }
     

--- a/module_bindings/dripline_cpp/message/DriplineCppMessage.hh
+++ b/module_bindings/dripline_cpp/message/DriplineCppMessage.hh
@@ -97,11 +97,11 @@ namespace dripline_cpp_pybind
         ************/
         pybind11::class_<dripline::msg_reply, dripline::py_msg_reply> msg_reply (mod, "dripline_msg_reply", message);
         msg_reply.def(pybind11::init< >( ));
-/*
-        msg_reply.def_static("create", (dripline::reply_ptr_t (dripline::msg_reply::*)(const dripline::return_code&, const std::string&, scarab::param_ptr_t, const std::string&, const std::string&, dripline::message::encoding)) &dripline::msg_reply::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_encoding") = dripline::encoding::json)
-                 .def_static("create", (dripline::reply_ptr_t (dripline::msg_reply::*)(const dripline::return_code&, const std::string&, scarab::param_ptr_t, const std::string&, const dripline::msg_request&)) &dripline::msg_r::create)
-                 .def_static("create", (dripline::reply_ptr_t (dripline::msg_reply::*)(unsigned, const std::string&, scarab::param_ptr_t, const std::string&, const std::string&, message::encoding)) &dripline::msg_reply::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_encoding") = dripline::encoding::json);
-*/
+
+//        msg_reply.def_static("create", (dripline::reply_ptr_t (dripline::msg_reply::*)(const dripline::return_code&, const std::string&, scarab::param_ptr_t, const std::string&, const std::string&, dripline::message::encoding)) &dripline::msg_reply::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_encoding") = dripline::message::encoding::json)
+//                 .def_static("create", (dripline::reply_ptr_t (dripline::msg_reply::*)(const dripline::return_code&, const std::string&, const dripline::msg_request&)) &dripline::msg_reply::create)
+//                 .def_static("create", (dripline::reply_ptr_t (dripline::msg_reply::*)(unsigned, const std::string&, scarab::param_ptr_t, const std::string&, const std::string&, dripline::message::encoding)) &dripline::msg_reply::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_encoding") = dripline::message::encoding::json);
+
         msg_reply.def("is_request", &dripline::msg_reply::is_request)
                  .def("is_reply", &dripline::msg_reply::is_reply)
                  .def("is_alert", &dripline::msg_reply::is_alert);
@@ -121,9 +121,9 @@ namespace dripline_cpp_pybind
         pybind11::class_<dripline::msg_alert, dripline::py_msg_alert> msg_alert (mod, "dripline_msg_alert", message);
             
         msg_alert.def(pybind11::init< >( ));
-/*
-        msg_alert.def_static("create", &dripline::msg_alert::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_encoding") = dripline::encoding::json);
-*/
+
+//        msg_alert.def_static("create", &dripline::msg_alert::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_encoding") = dripline::message::encoding::json);
+
         msg_alert.def("is_request", &dripline::msg_alert::is_request)
                  .def("is_reply", &dripline::msg_alert::is_reply)
                  .def("is_alert", &dripline::msg_alert::is_alert);

--- a/module_bindings/dripline_cpp/message/DriplineCppMessage.hh
+++ b/module_bindings/dripline_cpp/message/DriplineCppMessage.hh
@@ -28,31 +28,27 @@ namespace dripline_cpp_pybind
                .def("create_amqp_message", &dripline::message::create_amqp_message, "From message object to AMQP")
                .def("encode_message_body", &dripline::message::encode_message_body, "From message object to string");
 
-        // not tested yet
-/*              
                 // mv_referrable
         message.def("get_routing_key", (std::string& (dripline::message::*)()) &dripline::message::routing_key)
                .def("get_correlation_id", (std::string& (dripline::message::*)()) &dripline::message::correlation_id)
-               .def("get_reply_to", (std::string& (dripline::message::*)() &dripline::message::reply_to)
-               .def("get_timestamp", (std::string& (dripline::message::*)() &dripline::message::timestamp)
+               .def("get_reply_to", (std::string& (dripline::message::*)()) &dripline::message::reply_to)
+               .def("get_timestamp", (std::string& (dripline::message::*)()) &dripline::message::timestamp)
 
                 // mv_accessible
-               .def("get_encoding", (void (dripline::message::*)(dripline::message::encoding) &dripline::message::get_encoding)
+               .def("get_encoding", (void (dripline::message::*)(dripline::message::encoding)) &dripline::message::get_encoding)
 
                 // mv_referrable_const
                .def("get_sender_package", &dripline::message::sender_package)
                .def("get_sender_exe", &dripline::message::sender_exe)
                .def("get_sender_version", &dripline::message::sender_version)
                .def("get_sender_commit", &dripline::message::sender_commit)
-               .def("get_sender_hostname", &dripline::message::get_sender_hostname)
-               .def("get_sender_username", &dripline::message::get_sender_username)
-               .def("get_sender_service_name", &dripline::message::get_sender_service_name)
+               .def("get_sender_hostname", &dripline::message::sender_hostname)
+               .def("get_sender_username", &dripline::message::sender_username)
+               .def("get_sender_service_name", &dripline::message::sender_service_name)
                .def("get_sender_info", &dripline::message::sender_info);
 
-        message.def("parsed_specifier", (dripline::specifier& (dripline::message::*)())&dripline::message::parsed_specifier);
+        message.def("parsed_specifier", (dripline::specifier& (dripline::message::*)())&dripline::message::parsed_specifier)
                .def("message_type", &dripline::message::message_type);
-*/
-
 
         message.def("set_sender_package", &dripline::message::set_sender_package)
                .def("set_sender_exe", &dripline::message::set_sender_version)
@@ -62,13 +58,12 @@ namespace dripline_cpp_pybind
                .def("set_sender_username", &dripline::message::set_sender_username)
                .def("set_sender_service_name", &dripline::message::set_sender_service_name)
                .def("set_sender_info", &dripline::message::set_sender_info);
-/*
-        message.def("payload", (const scarab::param& (dripline::message::*)())&dripline::message::payload)
-               .def("set_payload", &dripline::message::set_payload);
 
-        message.def("__repr__", [std::string]() { std::string t_msg;
-                                       return this->encode_message_body(t_msg); });
-*/
+        message.def("payload", (scarab::param& (dripline::message::*)())&dripline::message::payload);
+//               .def("set_payload", &dripline::message::set_payload);
+
+        message.def("__repr__", [](const dripline::message& a_message) { std::string t_msg;
+                                       return a_message.encode_message_body(t_msg); });
 
         /************
          msg_request
@@ -129,11 +124,11 @@ namespace dripline_cpp_pybind
         msg_alert.def(pybind11::init< >( ));
 /*
         msg_alert.def_static("create", &dripline::msg_alert::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_encoding") = dripline::encoding::json);
-
+*/
         msg_alert.def("is_request", &dripline::msg_alert::is_request)
                  .def("is_reply", &dripline::msg_alert::is_reply)
                  .def("is_alert", &dripline::msg_alert::is_alert);
-*/
+
         msg_alert.def("message_type", &dripline::msg_alert::message_type);
 
 //        msg_alert.def_static("get_message_type", &dripline::msg_alert::get_message_type);

--- a/module_bindings/dripline_cpp/message/DriplineCppMessage.hh
+++ b/module_bindings/dripline_cpp/message/DriplineCppMessage.hh
@@ -37,7 +37,7 @@ namespace dripline_cpp_pybind
                .def("get_timestamp", (std::string& (dripline::message::*)() &dripline::message::timestamp)
 
                 // mv_accessible
-               .def("set_encoding", (void (dripline::message::*)(dripline::message::encoding) &dripline::message::set_encoding)
+               .def("get_encoding", (void (dripline::message::*)(dripline::message::encoding) &dripline::message::get_encoding)
 
                 // mv_referrable_const
                .def("get_sender_package", &dripline::message::sender_package)
@@ -66,9 +66,8 @@ namespace dripline_cpp_pybind
         message.def("payload", (const scarab::param& (dripline::message::*)())&dripline::message::payload)
                .def("set_payload", &dripline::message::set_payload);
 
-        // originally << - need better ones
-        message.def("encoding_ostream", [](std::ostream& a_os, message::encoding a_enc) { a_os << a_enc })
-               .def("message_ostream", [](std::ostream& a_os, const dripline::message& a_message) { a_os << a_message });
+        message.def("__repr__", [std::string]() { std::string t_msg;
+                                       return this->encode_message_body(t_msg); });
 */
 
         /************
@@ -77,68 +76,68 @@ namespace dripline_cpp_pybind
         pybind11::class_<dripline::msg_request, dripline::py_msg_request> msg_request (mod, "dripline_msg_request", message);
 
         msg_request.def(pybind11::init< >( ));
-        //msg_request.def_static("create", &dripline::msg_request::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_reply_to") = "", pybind11::arg("a_encoding") = dripline::encoding::json);
+//        msg_request.def_static("create", &dripline::msg_request::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_reply_to") = "", pybind11::arg("a_encoding") = dripline::encoding::json);
 
         msg_request.def("is_request", &dripline::msg_request::is_request)
                    .def("is_reply", &dripline::msg_request::is_reply)
                    .def("is_alert", &dripline::msg_request::is_alert);
 
-        msg_request.def("reply", &dripline::msg_request::reply, pybind11::arg("a_payload") = scarab::param_ptr_t(new scarab::param()));
+//        msg_request.def("reply", &dripline::msg_request::reply, pybind11::arg("a_payload") = scarab::param_ptr_t(new scarab::param()));
 
-/*
+
         msg_request.def("message_type", &dripline::msg_request::message_type);
-
+/*
                     // mv_accessible_static_noset
         msg_request.def_static("get_message_type", &dripline::msg_request::get_message_type)
                     // mv_referrable
                     // TODO: have not found where the definition of uuid is
                    .def("get_lockout_key", (uuid& (dripline::msg_request::*)()) &dripline::msg_request::lockout_key)
                     // mv_accessible
-                   .def("set_lockout_key_valid", (void (dripline::msg_request::*)(bool) &dripline::msg_request::set_lockout_key_valid)
+                   .def("get_lockout_key_valid", (void (dripline::msg_request::*)(bool) &dripline::msg_request::get_lockout_key_valid)
                     // TODO: have not found where the definition of op_t is
-                   .def("set_message_op", (void (dripline::msg_request::*)(op_t) &dripline::msg_request::set_message_op);
+                   .def("get_message_op", (void (dripline::msg_request::*)(op_t) &dripline::msg_request::get_message_op);
 */
 
         /************
          msg_reply
-        ************
-        pybind11::class_<dripline::msg_reply, dripline::py_msg_reply> msg_reply (mod, "dripline_msg_reply");
+        ************/
+        pybind11::class_<dripline::msg_reply, dripline::py_msg_reply> msg_reply (mod, "dripline_msg_reply", message);
         msg_reply.def(pybind11::init< >( ));
-
+/*
         msg_reply.def_static("create", (dripline::reply_ptr_t (dripline::msg_reply::*)(const dripline::return_code&, const std::string&, scarab::param_ptr_t, const std::string&, const std::string&, dripline::message::encoding)) &dripline::msg_reply::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_encoding") = dripline::encoding::json)
                  .def_static("create", (dripline::reply_ptr_t (dripline::msg_reply::*)(const dripline::return_code&, const std::string&, scarab::param_ptr_t, const std::string&, const dripline::msg_request&)) &dripline::msg_r::create)
                  .def_static("create", (dripline::reply_ptr_t (dripline::msg_reply::*)(unsigned, const std::string&, scarab::param_ptr_t, const std::string&, const std::string&, message::encoding)) &dripline::msg_reply::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_encoding") = dripline::encoding::json);
-
+*/
         msg_reply.def("is_request", &dripline::msg_reply::is_request)
                  .def("is_reply", &dripline::msg_reply::is_reply)
                  .def("is_alert", &dripline::msg_reply::is_alert);
 
         msg_reply.def("message_type", &dripline::msg_reply::message_type);
-
+/*
                   // mv_accessible_static_noset
         msg_reply.def_static("get_message_type", &dripline::msg_reply::get_message_type)
                   // mv_referrable
                  .def("get_return_msg", (std::string& (dripline::msg_reply::*)()) &dripline::msg_reply::return_msg)
                   // mv_accessible
-                 .def("set_return_code", (void (dripline::msg_request::*)(unsigned) &dripline::msg_reply::set_return_code);
-
+                 .def("get_return_code", (void (dripline::msg_request::*)(unsigned) &dripline::msg_reply::get_return_code);
+*/
         /************
          msg_alert
-        ************
-        pybind11::class_<dripline::msg_alert, dripline::py_msg_alert> msg_alert (mod, "dripline_msg_alert");
+        ************/
+        pybind11::class_<dripline::msg_alert, dripline::py_msg_alert> msg_alert (mod, "dripline_msg_alert", message);
             
         msg_alert.def(pybind11::init< >( ));
-
+/*
         msg_alert.def_static("create", &dripline::msg_alert::create, pybind11::arg("a_specifier") = "", pybind11::arg("a_encoding") = dripline::encoding::json);
 
         msg_alert.def("is_request", &dripline::msg_alert::is_request)
                  .def("is_reply", &dripline::msg_alert::is_reply)
                  .def("is_alert", &dripline::msg_alert::is_alert);
-
+*/
         msg_alert.def("message_type", &dripline::msg_alert::message_type);
 
-        msg_alert.def_static("get_message_type", &dripline::msg_alert::get_message_type);
-*/
+//        msg_alert.def_static("get_message_type", &dripline::msg_alert::get_message_type);
+
     }
     
 } /* namespace dripline_cpp_pybind */

--- a/module_bindings/dripline_cpp/message/DriplineCppMessage.hh
+++ b/module_bindings/dripline_cpp/message/DriplineCppMessage.hh
@@ -64,6 +64,7 @@ namespace dripline_cpp_pybind
 
         message.def("__repr__", [](const dripline::message& a_message) { std::string t_msg;
                                        return a_message.encode_message_body(t_msg); });
+        // operator << ?
 
         /************
          msg_request
@@ -81,17 +82,15 @@ namespace dripline_cpp_pybind
 
 
         msg_request.def("message_type", &dripline::msg_request::message_type);
-/*
+
                     // mv_accessible_static_noset
         msg_request.def_static("get_message_type", &dripline::msg_request::get_message_type)
                     // mv_referrable
-                    // TODO: have not found where the definition of uuid is
-                   .def("get_lockout_key", (uuid& (dripline::msg_request::*)()) &dripline::msg_request::lockout_key)
+                   .def("get_lockout_key", (boost::uuids::uuid& (dripline::msg_request::*)()) &dripline::msg_request::lockout_key)
                     // mv_accessible
-                   .def("get_lockout_key_valid", (void (dripline::msg_request::*)(bool) &dripline::msg_request::get_lockout_key_valid)
-                    // TODO: have not found where the definition of op_t is
-                   .def("get_message_op", (void (dripline::msg_request::*)(op_t) &dripline::msg_request::get_message_op);
-*/
+                   .def("get_lockout_key_valid", (void (dripline::msg_request::*)(bool)) &dripline::msg_request::get_lockout_key_valid);
+//                   .def("get_message_op", (void (dripline::msg_request::*)(op_t)) &dripline::msg_request::get_message_op);
+
 
         /************
          msg_reply
@@ -108,14 +107,14 @@ namespace dripline_cpp_pybind
                  .def("is_alert", &dripline::msg_reply::is_alert);
 
         msg_reply.def("message_type", &dripline::msg_reply::message_type);
-/*
+
                   // mv_accessible_static_noset
         msg_reply.def_static("get_message_type", &dripline::msg_reply::get_message_type)
                   // mv_referrable
                  .def("get_return_msg", (std::string& (dripline::msg_reply::*)()) &dripline::msg_reply::return_msg)
                   // mv_accessible
-                 .def("get_return_code", (void (dripline::msg_request::*)(unsigned) &dripline::msg_reply::get_return_code);
-*/
+                 .def("get_return_code", (void (dripline::msg_reply::*)(unsigned)) &dripline::msg_reply::get_return_code);
+
         /************
          msg_alert
         ************/
@@ -130,8 +129,8 @@ namespace dripline_cpp_pybind
                  .def("is_alert", &dripline::msg_alert::is_alert);
 
         msg_alert.def("message_type", &dripline::msg_alert::message_type);
-
-//        msg_alert.def_static("get_message_type", &dripline::msg_alert::get_message_type);
+                  // mv_accessible_static_noset
+        msg_alert.def_static("get_message_type", &dripline::msg_alert::get_message_type);
 
     }
     

--- a/module_bindings/dripline_cpp/message/DriplineCppMessageVirtual.hh
+++ b/module_bindings/dripline_cpp/message/DriplineCppMessageVirtual.hh
@@ -105,7 +105,7 @@ namespace dripline
         }
 
     };
-/*
+
     class py_msg_reply: public msg_reply {
     public:
         using msg_reply::msg_reply;
@@ -190,5 +190,5 @@ namespace dripline
 
 
     };
-*/
+
 }


### PR DESCRIPTION
Sorry for getting back late.

So far there are still some functions not working - all the `create()` functions for derived message classes and other 3 (`message.set_payload()`, `msg_request.reply()` and `msg_request.get_message_op()`), and I am not quite sure why.

Please feel free to get in touch with me via email/GitHub - somehow I am not able to use Slack from where I am now :(