### PR TITLE
Update error codes to match psyllid/dripline-cpp update.

### DIFF
--- a/dripline/core/exceptions.py
+++ b/dripline/core/exceptions.py
@@ -136,15 +136,15 @@ class DriplineDatabaseError(DriplineError):
 __all__.append("DriplineDatabaseError")
 
 class DriplineGenericDAQError(DriplineError):
-    retcode = 500
+    retcode = 1100
 __all__.append("DriplineGenericDAQError")
 
 class DriplineDAQNotEnabled(DriplineError):
-    retcode = 501
+    retcode = 1101
 __all__.append("DriplineDAQNotEnabled")
 
 class DriplineDAQRunning(DriplineError):
-    retcode = 502
+    retcode = 1102
 __all__.append("DriplineDAQRunning")
 
 class DriplineUnhandledError(DriplineError):

--- a/dripline/core/exceptions.py
+++ b/dripline/core/exceptions.py
@@ -59,11 +59,9 @@ class DriplineAMQPError(DriplineError):
     retcode = 100
 __all__.append('DriplineAMQPError')
 
-
 class DriplineAMQPConnectionError(DriplineError):
     retcode = 101
 __all__.append('DriplineAMQPConnectionError')
-
 
 class DriplineAMQPRoutingKeyError(DriplineError):
     retcode = 102
@@ -74,11 +72,9 @@ class DriplineHardwareError(DriplineError):
     retcode = 200
 __all__.append('DriplineHardwareError')
 
-
 class DriplineHardwareConnectionError(DriplineError):
     retcode = 201
 __all__.append('DriplineHardwareConnectionError')
-
 
 class DriplineHardwareResponselessError(DriplineError):
     retcode = 202
@@ -89,31 +85,25 @@ class DriplineInternalError(DriplineError):
     retcode = 300
 __all__.append('DriplineInternalError')
 
-
 class DriplineNoMessageEncodingError(DriplineError):
     retcode = 301
 __all__.append('DriplineNoMessageEncodingError')
-
 
 class DriplineDecodingError(DriplineError):
     retcode = 302
 __all__.append('DriplineDecodingError')
 
-
 class DriplinePayloadError(DriplineError):
     retcode = 303
 __all__.append('DriplinePayloadError')
-
 
 class DriplineValueError(DriplineError):
     retcode = 304
 __all__.append('DriplineValueError')
 
-
 class DriplineTimeoutError(DriplineError):
     retcode = 305
 __all__.append('DriplineTimeoutError')
-
 
 class DriplineMethodNotSupportedError(DriplineError):
     retcode = 306
@@ -131,9 +121,27 @@ class DriplineDeprecated(DriplineError):
     retcode = 309
 __all__.append('DriplineDeprecated')
 
-class DriplineDatabaseError(DriplineError):
+
+class DriplineClientError(DriplineError):
     retcode = 400
-__all__.append("DriplineDatabaseError")
+__all__.append('DriplineClientError')
+
+class DriplineClientRequestError(DriplineError):
+    retcode = 401
+__all__.append('DriplineClientRequestError')
+
+class DriplineClientReplyError(DriplineError):
+    retcode = 402
+__all__.append('DriplineClientReplyError')
+
+class DriplineClientSendError(DriplineError):
+    retcode = 403
+__all__.append('DriplineClientSendError')
+
+class DriplineClientTimeoutError(DriplineError):
+    retcode = 404
+__all__.append('DriplineClientTimeoutError')
+
 
 class DriplineGenericDAQError(DriplineError):
     retcode = 1100
@@ -146,6 +154,12 @@ __all__.append("DriplineDAQNotEnabled")
 class DriplineDAQRunning(DriplineError):
     retcode = 1102
 __all__.append("DriplineDAQRunning")
+
+
+class DriplineDatabaseError(DriplineError):
+    retcode = 1200
+__all__.append("DriplineDatabaseError")
+
 
 class DriplineUnhandledError(DriplineError):
     retcode = 999

--- a/dripline/core/spime.py
+++ b/dripline/core/spime.py
@@ -151,7 +151,7 @@ class Spime(Endpoint, Scheduler):
         elif (this_value is not False) and\
              ((self._last_log_value == 0 and this_value != 0) or
               (self._last_log_value != 0 and\
-                (abs(self._last_log_value - this_value)/self._last_log_value)>self.max_fractional_change)):
+                abs((self._last_log_value - this_value)/self._last_log_value)>self.max_fractional_change)):
             logger.debug('log b/c change is too large')
         else:
             logger.debug('no log condition met, not logging')


### PR DESCRIPTION
WP changing to move specific error codes out of dripline space.  This makes python match dripline-cpp behavior.

We should come back later and clean-up `exception_map` to handle case of unknown exceptions.