### PR TITLE
Feature/external build refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,19 +10,20 @@ RUN apt-get update && apt-get install -y \
         wget &&\
     rm -rf /var/lib/apt/lists/*
 
-COPY pybind11 /usr/local/src/pybind11
+#COPY pybind11 /usr/local/src/pybind11
 COPY dripline-cpp /usr/local/src/dripline-cpp
 COPY module_bindings /usr/local/src/module_bindings
+COPY dripline /usr/local/src/dripline
+COPY bin /usr/local/src/bin
 COPY .git /usr/local/src/.git
 COPY setup.py /usr/local/src/setup.py
 COPY CMakeLists.txt /usr/local/src/CMakeLists.txt
 
-# I'd really like to figure out how to get the dripline libraries installed to /usr/local/lib, outside of python...
-RUN echo "# cmake installed libraries" > /etc/ld.so.conf.d/dripline.conf &&\
-    echo "/usr/local/lib/python3.5/site-packages" >> /etc/ld.so.conf.d/dripline.conf &&\
-    ldconfig
+## would prefer not to do this, just run ldconfig after the build to get things
+## into the ld.so.conf cache... use this only when developing and adding libs
+ENV LD_LIBRARY_PATH /usr/local/lib
 
-RUN cd /usr/local/src && \
-    pip -v install . && \
-    ldconfig && \
-    /bin/true
+#RUN cd /usr/local/src && \
+RUN pip --disable-pip-version-check install -v /usr/local/src
+#    ldconfig
+#    /bin/true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
       #- ./CMakeLists.txt:/usr/local/src/CMakeLists.txt
       #- ./setup.py:/usr/local/src/setup.py
       - .:/usr/local/src
+      - ./auths.json:/root/p8_auths.json
   rabbit-broker:
     image: rabbitmq:3-management
     environment:

--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,11 @@ class CMakeBuild(build_ext):
         print("should make a cmake call:")
         print(' '.join(['cmake', ext.sourcedir] + cmake_args), 'cwd={}'.format(self.build_temp), 'env={}'.format(env))
         subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
         print("should make a build call:")
         print(['cmake', '--build', '.'] + build_args, 'cwd={}'.format(self.build_temp))
-        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
+        #subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
+        subprocess.check_call(['make', 'install'], cwd=self.build_temp)
 
 requirements = [
     'PyYAML',


### PR DESCRIPTION
- Dockerfile now actually copies up everything required to build
- modified the externals build procedure to properly build dripline-cpp components we want included.