### PR TITLE
dl-serve module import fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ ENV LD_LIBRARY_PATH /usr/local/lib
 
 RUN pip install ipython
 
-RUN cd /usr/local/src &&\
-    python setup.py install
+RUN pip install /usr/local/src
 RUN ldconfig
 

--- a/bin/dl-serve
+++ b/bin/dl-serve
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import datetime
+import inspect
 import traceback
 
 import yaml
@@ -23,20 +24,27 @@ class Serve:
             except IOError as e:
                 print("unable to load source from: {}".format(module_path))
                 raise e
+        module = None
         #first priority, if it is in the module_path provided (if any)
         if hasattr(extra_namespace, module_name):
             module = getattr(extra_namespace, module_name)
         #second priority, if it is in any extensions installed
         elif hasattr(dripline.extensions, module_name):
             module = getattr(dripline.extensions, module_name)
+        ## Note: we only loop one layer down, this could possibly be made more generic
+        for m in [getattr(dripline.extensions, i_mod) for i_mod in dir(dripline.extensions)]:
+            if inspect.ismodule(m):
+                if hasattr(m, module_name):
+                    module = getattr(m, module_name)
+        if module is None: # continue above elifs
         #third priority, if it is part of the base set of implementations
-        elif hasattr(dripline.implementations, module_name):
-            module = getattr(dripline.implementations, module_name)
+            if hasattr(dripline.implementations, module_name):
+                module = getattr(dripline.implementations, module_name)
         #fourth priority, if it is in core
-        elif hasattr(dripline.core, module_name):
-            module = getattr(dripline.core, module_name)
-        else:
-            raise NameError('no module "{}" in available namespaces'.format(module_name))
+            elif hasattr(dripline.core, module_name):
+                module = getattr(dripline.core, module_name)
+            else:
+                raise NameError('no module "{}" in available namespaces'.format(module_name))
         the_object = module( **a_config )
 
         return the_object


### PR DESCRIPTION
So my test was:
1) docker build this repo
2) docker-compose with a mount for also `dripline-python-extension-example`
3) run the container and `pip install ` the extension repo
4) `dl-serve -c /path/to/kv_store_tutorial.yaml --auth-file /root/auths.json`

And that works and is able to make the amqp connection as expected.