### PR TITLE
Feature/alert consumer

### DIFF
--- a/dripline/core/__init__.py
+++ b/dripline/core/__init__.py
@@ -2,8 +2,9 @@ __all__ = []
 
 import scarab
 from _dripline.core import *
+
+from .alert_consumer import *
 from .calibrate import *
 from .endpoint import *
 from .entity import *
 from .interface import *
-#from .key_value_store import *

--- a/dripline/core/alert_consumer.py
+++ b/dripline/core/alert_consumer.py
@@ -1,3 +1,5 @@
+import re
+
 from _dripline.core import Service
 
 __all__ = []
@@ -12,10 +14,18 @@ class AlertConsumer(Service):
     2) Use the existing on_alert_message, which proceeds in two steps by calling parse_routing_key, followed by process_payload.
        The first may be used or overriden, the second must always be implemented.
     '''
-    def __init__(self, alert_keys=["#"], **kwargs):
+    def __init__(self, alert_keys=["#"], alert_key_parser_re='', **kwargs):
+        '''
+        alert_keys: an iterable of strings which will be used as binding keys on the alerts exchange
+        alert_key_parser_re: a regular expression (see python's re library) which is used in the default implementation
+                             of parse_routing_key to extract useful data from the incoming routing key.  Note: a failed
+                             match will return an empty dict, you are responsible for checkin and deciding if this is an
+                             error. We use re.match and return the groupdict.
+        '''
         print("in AlertConsumer init")
         Service.__init__(self, **kwargs)
         self._alert_keys = alert_keys
+        self._alert_key_parser_re= alert_key_parser_re
 
     def bind_keys(self):
         print("in python's bind keys")
@@ -28,10 +38,18 @@ class AlertConsumer(Service):
     def on_alert_message(self, an_alert):
         print("in python's on alert")
         routing_data = self.parse_routing_key(an_alert.routing_key)
-        self.process_payload(an_alert.payload, routing_data)
+        self.process_payload(an_alert.payload, routing_data, an_alert.timestamp)
 
     def parse_routing_key(self, a_routing_key):
-        pass
+        return_data = {}
+        print("routing key: '{}'".format(a_routing_key))
+        print("regex: '{}'".format(self._alert_key_parser_re))
+        re_result = re.match(self._alert_key_parser_re, a_routing_key)
+        if re_result:
+            return_data.update(re_result.groupdict())
+        else:
+            print("WARNING!! regular expression match failed to extract any data")
+        return return_data
 
-    def process_payload(self, a_payload, a_routing_key_data):
-        pass
+    def process_payload(self, a_payload, a_routing_key_data, a_message_timestamp):
+        print('got routing key data: {}\nwith payload: {}'.format(a_routing_key_data, a_payload))

--- a/dripline/core/alert_consumer.py
+++ b/dripline/core/alert_consumer.py
@@ -14,7 +14,7 @@ class AlertConsumer(Service):
         to_return = Service.bind_keys(self);
         for a_key in self._alert_keys:
             print(" binding alert key {}".format(a_key))
-            self.bind_key("alerts", a_key)
+            to_return = to_return and self.bind_key("alerts", a_key)
         return to_return
 
     def on_alert_message(self, an_alert):

--- a/dripline/core/alert_consumer.py
+++ b/dripline/core/alert_consumer.py
@@ -13,9 +13,8 @@ class AlertConsumer(Service):
         print("in python's bind keys")
         to_return = Service.bind_keys(self);
         for a_key in self._alert_keys:
-            # core::bind_key( channel, exchange, queue, key ) - all are strings
-            #self.bind_key()
-            pass
+            print(" binding alert key {}".format(a_key))
+            self.bind_key("alerts", a_key)
         return to_return
 
     def on_alert_message(self, an_alert):

--- a/dripline/core/alert_consumer.py
+++ b/dripline/core/alert_consumer.py
@@ -1,0 +1,7 @@
+from _dripline.core import Service
+
+__all__ = []
+
+__all__.append('AlertConsumer')
+class AlertConsumer(Service)
+    pass

--- a/dripline/core/alert_consumer.py
+++ b/dripline/core/alert_consumer.py
@@ -4,6 +4,14 @@ __all__ = []
 
 __all__.append('AlertConsumer')
 class AlertConsumer(Service):
+    '''
+    A base class for implementing custom alert message consumers.
+
+    One is expected to extend this class in one of two ways:
+    1) More advanced: override the existing on_alert_message method with whatever behavior is desired
+    2) Use the existing on_alert_message, which proceeds in two steps by calling parse_routing_key, followed by process_payload.
+       The first may be used or overriden, the second must always be implemented.
+    '''
     def __init__(self, alert_keys=["#"], **kwargs):
         print("in AlertConsumer init")
         Service.__init__(self, **kwargs)
@@ -19,3 +27,11 @@ class AlertConsumer(Service):
 
     def on_alert_message(self, an_alert):
         print("in python's on alert")
+        routing_data = self.parse_routing_key(an_alert.routing_key)
+        self.process_payload(an_alert.payload, routing_data)
+
+    def parse_routing_key(self, a_routing_key):
+        pass
+
+    def process_payload(self, a_payload, a_routing_key_data):
+        pass

--- a/dripline/core/alert_consumer.py
+++ b/dripline/core/alert_consumer.py
@@ -3,5 +3,20 @@ from _dripline.core import Service
 __all__ = []
 
 __all__.append('AlertConsumer')
-class AlertConsumer(Service)
-    pass
+class AlertConsumer(Service):
+    def __init__(self, alert_keys=["#"], **kwargs):
+        print("in AlertConsumer init")
+        Service.__init__(self, **kwargs)
+        self._alert_keys = alert_keys
+
+    def bind_keys(self):
+        print("in python's bind keys")
+        to_return = Service.bind_keys(self);
+        for a_key in self._alert_keys:
+            # core::bind_key( channel, exchange, queue, key ) - all are strings
+            #self.bind_key()
+            pass
+        return to_return
+
+    def on_alert_message(self, an_alert):
+        print("in python's on alert")

--- a/examples/alert_consumer.yaml
+++ b/examples/alert_consumer.yaml
@@ -2,6 +2,7 @@ runtime-config:
   name: alert_consumer_example
   module: AlertConsumer
   auth_file: /root/auths.json
+  alert_key_parser_re: 'sensor_value\.(?P<from>\w+)'
 #  endpoints:
 #        - name: peaches
 #          module: KeyValueStore

--- a/examples/alert_consumer.yaml
+++ b/examples/alert_consumer.yaml
@@ -3,28 +3,3 @@ runtime-config:
   module: AlertConsumer
   auth_file: /root/auths.json
   alert_key_parser_re: 'sensor_value\.(?P<from>\w+)'
-#  endpoints:
-#        - name: peaches
-#          module: KeyValueStore
-#          calibration: '2*{}'
-#          initial_value: 0.75
-#          log_interval: 10
-#          get_on_set: True
-#          log_on_set: True
-#        - name: chips
-#          module: KeyValueStore
-#          calibration: 'times3({})'
-#          initial_value: 1.75
-#        - name: waffles
-#          module: KeyValueStore
-#          #log_interval: 30
-#          #log_on_set: True
-#          calibration: '1.*{}'
-#          initial_value: 4.00
-#        - name: peaches_status
-#          #log_on_set: True
-#          module: KeyValueStore
-#          initial_value: "CLOSE"
-#          calibration:
-#              CLOSE: "on"
-#              OPEN: "off"

--- a/examples/alert_consumer.yaml
+++ b/examples/alert_consumer.yaml
@@ -1,0 +1,29 @@
+runtime-config:
+  name: alert_consumer_example
+  module: AlertConsumer
+  auth_file: /root/auths.json
+#  endpoints:
+#        - name: peaches
+#          module: KeyValueStore
+#          calibration: '2*{}'
+#          initial_value: 0.75
+#          log_interval: 10
+#          get_on_set: True
+#          log_on_set: True
+#        - name: chips
+#          module: KeyValueStore
+#          calibration: 'times3({})'
+#          initial_value: 1.75
+#        - name: waffles
+#          module: KeyValueStore
+#          #log_interval: 30
+#          #log_on_set: True
+#          calibration: '1.*{}'
+#          initial_value: 4.00
+#        - name: peaches_status
+#          #log_on_set: True
+#          module: KeyValueStore
+#          initial_value: "CLOSE"
+#          calibration:
+#              CLOSE: "on"
+#              OPEN: "off"

--- a/module_bindings/CMakeLists.txt
+++ b/module_bindings/CMakeLists.txt
@@ -15,6 +15,8 @@ set( PB_DRIPLINE_CORE_HEADERFILES
     dripline_core/return_codes.hh
     dripline_core/return_code_trampoline.hh
     dripline_core/return_code_functions.hh
+    dripline_core/service_pybind.hh
+    dripline_core/service_trampoline.hh
     dripline_core/scheduler_pybind.hh
     dripline_core/version_store_pybind.hh
 )

--- a/module_bindings/dripline_core/_endpoint_pybind.hh
+++ b/module_bindings/dripline_core/_endpoint_pybind.hh
@@ -11,14 +11,6 @@
 namespace dripline_pybind
 {
 
-    class _endpoint : public dripline::endpoint
-    {
-        public:
-            using dripline::endpoint::do_get_request;
-            using dripline::endpoint::do_set_request;
-            using dripline::endpoint::do_cmd_request;
-    };
-
     std::list< std::string > export_endpoint( pybind11::module& mod )
     {
         std::list< std::string > all_items;
@@ -39,29 +31,30 @@ namespace dripline_pybind
                   pybind11::call_guard< pybind11::scoped_ostream_redirect,
                                         pybind11::scoped_estream_redirect,
                                         pybind11::gil_scoped_release >() )
-            .def( "on_request_message", &_endpoint::on_request_message,
+            .def( "on_request_message", &dripline::endpoint::on_request_message,
                   pybind11::call_guard< pybind11::scoped_ostream_redirect,
                                         pybind11::scoped_estream_redirect,
                                         pybind11::gil_scoped_release >() )
-            .def( "on_reply_message", &_endpoint::on_reply_message,
+            .def( "on_reply_message", &dripline::endpoint::on_reply_message,
                   pybind11::call_guard< pybind11::scoped_ostream_redirect,
                                         pybind11::scoped_estream_redirect,
                                         pybind11::gil_scoped_release >() )
-            .def( "on_alert_message", &_endpoint::on_alert_message,
+            .def( "on_alert_message", &dripline::endpoint::on_alert_message,
                   pybind11::call_guard< pybind11::scoped_ostream_redirect,
                                         pybind11::scoped_estream_redirect,
                                         pybind11::gil_scoped_release >() )
-            .def( "do_get_request", &_endpoint::do_get_request,
+            .def( "do_get_request", &dripline::endpoint::do_get_request,
                   pybind11::call_guard< pybind11::scoped_ostream_redirect,
                                         pybind11::scoped_estream_redirect,
                                         pybind11::gil_scoped_release >() )
-            .def( "do_set_request", &_endpoint::do_set_request,
+            .def( "do_set_request", &dripline::endpoint::do_set_request,
                   pybind11::call_guard< pybind11::scoped_ostream_redirect,
                                         pybind11::scoped_estream_redirect,
                                         pybind11::gil_scoped_release >() )
-            .def( "do_cmd_request", &_endpoint::do_cmd_request,
+            .def( "do_cmd_request", &dripline::endpoint::do_cmd_request,
                   pybind11::call_guard< pybind11::scoped_ostream_redirect,
-                                          pybind11::scoped_estream_redirect >() )
+                                        pybind11::scoped_estream_redirect,
+                                        pybind11::gil_scoped_release >() )
             ;
             return all_items;
     }

--- a/module_bindings/dripline_core/service_pybind.hh
+++ b/module_bindings/dripline_core/service_pybind.hh
@@ -44,12 +44,13 @@ namespace dripline_pybind
 
             // mv_ bindings
             .def_property( "enable_scheduling", &dripline::service::get_enable_scheduling, &dripline::service::set_enable_scheduling )
-            //.def_property( "alerts_exchange", )
-            //.def_property( "requests_exchange", )
+            .def_property_readonly( "alerts_exchange", (std::string& (dripline::service::*)()) &dripline::service::alerts_exchange )
+            .def_property_readonly( "requests_exchange", (std::string& (dripline::service::*)()) &dripline::service::requests_exchange )
 
             .def( "bind_keys", &_service::bind_keys )
             .def( "bind_key",
-                  [](dripline::service& an_obj, std::string&  an_exchange, std::string& a_key){return _service::bind_key(an_obj.channel(), an_exchange, an_obj.name(), a_key);},
+                  // Note, need to take a service pointer so that we can accept derived types... I think
+                  [](_service* an_obj, std::string&  an_exchange, std::string& a_key){return _service::bind_key(an_obj->channel(), an_exchange, an_obj->name(), a_key);},
                   pybind11::arg( "exchange" ),
                   pybind11::arg( "key" )
             )
@@ -72,7 +73,7 @@ namespace dripline_pybind
                                         pybind11::scoped_estream_redirect >() )
             .def( "noisy_func", []() { pybind11::scoped_ostream_redirect stream(std::cout, pybind11::module::import("sys").attr("stdout"));})
 
-            //.def
+            .def( "on_alert_message", &_service::on_alert_message )
             ;
         return all_items;
     }

--- a/module_bindings/dripline_core/service_pybind.hh
+++ b/module_bindings/dripline_core/service_pybind.hh
@@ -47,7 +47,7 @@ namespace dripline_pybind
 
             .def( "bind_keys", &_service::bind_keys )
             .def( "bind_key",
-                  [](dripline::service& an_obj, std::string&  an_exchange, std::string& a_queue, std::string& a_key){return _service::bind_key(an_obj.channel(), an_exchange, a_queue, a_key)},
+                  [](dripline::service& an_obj, std::string&  an_exchange, std::string& a_queue, std::string& a_key){return _service::bind_key(an_obj.channel(), an_exchange, a_queue, a_key);},
                   pybind11::arg( "exchange" ),
                   pybind11::arg( "queue" ),
                   pybind11::arg( "key" )

--- a/module_bindings/dripline_core/service_pybind.hh
+++ b/module_bindings/dripline_core/service_pybind.hh
@@ -44,12 +44,13 @@ namespace dripline_pybind
 
             // mv_ bindings
             .def_property( "enable_scheduling", &dripline::service::get_enable_scheduling, &dripline::service::set_enable_scheduling )
+            //.def_property( "alerts_exchange", )
+            //.def_property( "requests_exchange", )
 
             .def( "bind_keys", &_service::bind_keys )
             .def( "bind_key",
-                  [](dripline::service& an_obj, std::string&  an_exchange, std::string& a_queue, std::string& a_key){return _service::bind_key(an_obj.channel(), an_exchange, a_queue, a_key);},
+                  [](dripline::service& an_obj, std::string&  an_exchange, std::string& a_key){return _service::bind_key(an_obj.channel(), an_exchange, an_obj.name(), a_key);},
                   pybind11::arg( "exchange" ),
-                  pybind11::arg( "queue" ),
                   pybind11::arg( "key" )
             )
             .def( "start", &dripline::service::start,

--- a/module_bindings/dripline_core/service_trampoline.hh
+++ b/module_bindings/dripline_core/service_trampoline.hh
@@ -12,7 +12,9 @@ namespace dripline_pybind
         public:
             using dripline::service::bind_keys;
             using dripline::core::bind_key;
+            using dripline::service::on_alert_message;
     };
+
     //class _service_trampoline : public dripline::service
     class _service_trampoline : public _service
     {

--- a/module_bindings/dripline_core/service_trampoline.hh
+++ b/module_bindings/dripline_core/service_trampoline.hh
@@ -1,0 +1,67 @@
+#ifndef DRIPLINE_PYBIND_SERVICE_TRAMPOLINE
+#define DRIPLINE_PYBIND_SERVICE_TRAMPOLINE
+
+#include "service.hh"
+
+namespace dripline_pybind
+{
+    class _service : public dripline::service
+    {
+        public:
+            using dripline::service::service;
+        public:
+            using dripline::service::bind_keys;
+            using dripline::core::bind_key;
+    };
+    //class _service_trampoline : public dripline::service
+    class _service_trampoline : public _service
+    {
+        public:
+            using _service::_service; //inherit constructors
+            // Local overrides
+            bool bind_keys() override
+            {
+                pybind11::gil_scoped_acquire t_acquire;
+                PYBIND11_OVERLOAD( bool, _service, bind_keys, );
+            }
+
+            //// Overrides from Endpoint
+            // Overrides for virtual on_[messgate-type]_message()
+            dripline::reply_ptr_t on_request_message( const dripline::request_ptr_t a_request ) override
+            {
+                pybind11::gil_scoped_acquire t_acquire;
+                PYBIND11_OVERLOAD( dripline::reply_ptr_t, dripline::endpoint, on_request_message, a_request );
+            }
+            void on_reply_message( const dripline::reply_ptr_t a_reply ) override
+            {
+                pybind11::gil_scoped_acquire t_acquire;
+                PYBIND11_OVERLOAD( void, dripline::endpoint, on_reply_message, a_reply );
+            }
+            void on_alert_message( const dripline::alert_ptr_t a_alert ) override
+            {
+                pybind11::gil_scoped_acquire t_acquire;
+                PYBIND11_OVERLOAD( void, dripline::endpoint, on_alert_message, a_alert );
+            }
+
+            // Overrides for virtual do_[request-type]_request
+            dripline::reply_ptr_t do_get_request( const dripline::request_ptr_t a_request ) override
+            {
+                pybind11::gil_scoped_acquire t_acquire;
+                PYBIND11_OVERLOAD( dripline::reply_ptr_t, dripline::endpoint, do_get_request, a_request );
+            }
+            dripline::reply_ptr_t do_set_request( const dripline::request_ptr_t a_request ) override
+            {
+                pybind11::gil_scoped_acquire t_acquire;
+                PYBIND11_OVERLOAD( dripline::reply_ptr_t, dripline::endpoint, do_set_request, a_request );
+            }
+            dripline::reply_ptr_t do_cmd_request( const dripline::request_ptr_t a_request ) override
+            {
+                pybind11::gil_scoped_acquire t_acquire;
+                PYBIND11_OVERLOAD( dripline::reply_ptr_t, dripline::endpoint, do_cmd_request, a_request );
+            }
+
+    };
+
+} /* namespace dripline_pybind */
+
+#endif /* DRIPLINE_PYBIND_SERVICE_TRAMPOLINE */

--- a/module_bindings/dripline_core/service_trampoline.hh
+++ b/module_bindings/dripline_core/service_trampoline.hh
@@ -9,10 +9,10 @@ namespace dripline_pybind
     {
         public:
             using dripline::service::service;
-        public:
+
             using dripline::service::bind_keys;
             using dripline::core::bind_key;
-            using dripline::service::on_alert_message;
+            using dripline::endpoint::on_alert_message;
     };
 
     //class _service_trampoline : public dripline::service
@@ -42,7 +42,7 @@ namespace dripline_pybind
             void on_alert_message( const dripline::alert_ptr_t a_alert ) override
             {
                 pybind11::gil_scoped_acquire t_acquire;
-                PYBIND11_OVERLOAD( void, dripline::endpoint, on_alert_message, a_alert );
+                PYBIND11_OVERLOAD( void, _service, on_alert_message, a_alert );
             }
 
             // Overrides for virtual do_[request-type]_request

--- a/module_bindings/dripline_core/service_trampoline.hh
+++ b/module_bindings/dripline_core/service_trampoline.hh
@@ -8,11 +8,13 @@ namespace dripline_pybind
     class _service : public dripline::service
     {
         public:
+            //inherit constructor
             using dripline::service::service;
 
+            //make methods public for use in overload macro
             using dripline::service::bind_keys;
             using dripline::core::bind_key;
-            using dripline::endpoint::on_alert_message;
+
     };
 
     //class _service_trampoline : public dripline::service
@@ -32,12 +34,12 @@ namespace dripline_pybind
             dripline::reply_ptr_t on_request_message( const dripline::request_ptr_t a_request ) override
             {
                 pybind11::gil_scoped_acquire t_acquire;
-                PYBIND11_OVERLOAD( dripline::reply_ptr_t, dripline::endpoint, on_request_message, a_request );
+                PYBIND11_OVERLOAD( dripline::reply_ptr_t, _service, on_request_message, a_request );
             }
             void on_reply_message( const dripline::reply_ptr_t a_reply ) override
             {
                 pybind11::gil_scoped_acquire t_acquire;
-                PYBIND11_OVERLOAD( void, dripline::endpoint, on_reply_message, a_reply );
+                PYBIND11_OVERLOAD( void, _service, on_reply_message, a_reply );
             }
             void on_alert_message( const dripline::alert_ptr_t a_alert ) override
             {
@@ -49,17 +51,17 @@ namespace dripline_pybind
             dripline::reply_ptr_t do_get_request( const dripline::request_ptr_t a_request ) override
             {
                 pybind11::gil_scoped_acquire t_acquire;
-                PYBIND11_OVERLOAD( dripline::reply_ptr_t, dripline::endpoint, do_get_request, a_request );
+                PYBIND11_OVERLOAD( dripline::reply_ptr_t, _service, do_get_request, a_request );
             }
             dripline::reply_ptr_t do_set_request( const dripline::request_ptr_t a_request ) override
             {
                 pybind11::gil_scoped_acquire t_acquire;
-                PYBIND11_OVERLOAD( dripline::reply_ptr_t, dripline::endpoint, do_set_request, a_request );
+                PYBIND11_OVERLOAD( dripline::reply_ptr_t, _service, do_set_request, a_request );
             }
             dripline::reply_ptr_t do_cmd_request( const dripline::request_ptr_t a_request ) override
             {
                 pybind11::gil_scoped_acquire t_acquire;
-                PYBIND11_OVERLOAD( dripline::reply_ptr_t, dripline::endpoint, do_cmd_request, a_request );
+                PYBIND11_OVERLOAD( dripline::reply_ptr_t, _service, do_cmd_request, a_request );
             }
 
     };


### PR DESCRIPTION
(includes #39 and a merge of feature/retcodes)

* Adds bindings for refactor return code objects and registration procedure.
* Bindings support newly virtual functions for processing message and request types  in derived endpoints (and services).
* Adds AlertConsumer class to serve as a base for implementations which want to consume alert messages, including helper to allow parsing of routing keys
* Added example config for a very simple AlertConsumer (using the base) which just prints things.