### PR TITLE
Dl3/pass init configs

### DIFF
--- a/module_bindings/CMakeLists.txt
+++ b/module_bindings/CMakeLists.txt
@@ -26,4 +26,5 @@ set( PB_DRIPLINE_CORE_SOURCEFILES
 )
 pybind11_add_module( _dripline ${PB_DRIPLINE_CORE_SOURCEFILES} )
 target_link_libraries( _dripline PRIVATE ${FULL_LIB_DEPENDENCIES} ${EXTERNAL_LIBRARIES} )
+set_property( GLOBAL APPEND PROPERTY Scarab_LIBRARIES _dripline)
 #install( TARGETS _dripline DESTINATION ${LIB_INSTALL_DIR} )

--- a/module_bindings/CMakeLists.txt
+++ b/module_bindings/CMakeLists.txt
@@ -26,5 +26,4 @@ set( PB_DRIPLINE_CORE_SOURCEFILES
 )
 pybind11_add_module( _dripline ${PB_DRIPLINE_CORE_SOURCEFILES} )
 target_link_libraries( _dripline PRIVATE ${FULL_LIB_DEPENDENCIES} ${EXTERNAL_LIBRARIES} )
-set_property( GLOBAL APPEND PROPERTY Scarab_LIBRARIES _dripline)
 #install( TARGETS _dripline DESTINATION ${LIB_INSTALL_DIR} )

--- a/module_bindings/dripline_core/service_pybind.hh
+++ b/module_bindings/dripline_core/service_pybind.hh
@@ -49,7 +49,7 @@ namespace dripline_pybind
                                       const unsigned int a_port,
                                       const std::string& a_auth_file,
                                       const bool a_make_connection )
-                                  { return new  _service( (scarab_pybind::to_param(a_config))->as_node(),
+                                  { return new  _service( (scarab_pybind::to_param(a_config, true))->as_node(),
                                                           a_name,
                                                           a_broker,
                                                           a_port,

--- a/module_bindings/dripline_core/service_pybind.hh
+++ b/module_bindings/dripline_core/service_pybind.hh
@@ -7,10 +7,11 @@
 #include "core.hh"
 #include "service.hh"
 
+#include "param_binding_helpers.hh"
+
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 #include "pybind11/iostream.h"
-
 
 
 namespace dripline_pybind
@@ -36,6 +37,26 @@ namespace dripline_pybind
                                 >(),
                    DL_BIND_CALL_GUARD_STREAMS,
                    pybind11::arg_v( "config", scarab::param_node(), "ParamNode()"),
+                   pybind11::arg( "name" ) = "",
+                   pybind11::arg( "broker" ) = "",
+                   pybind11::arg( "port" ) = 0,
+                   pybind11::arg( "auth_file" ) = "",
+                   pybind11::arg( "make_connection" ) = true
+            )
+            .def( pybind11::init( []( const pybind11::dict a_config,
+                                      const std::string& a_name,
+                                      const std::string& a_broker,
+                                      const unsigned int a_port,
+                                      const std::string& a_auth_file,
+                                      const bool a_make_connection )
+                                  { return new  _service( (scarab_pybind::to_param(a_config))->as_node(),
+                                                          a_name,
+                                                          a_broker,
+                                                          a_port,
+                                                          a_auth_file,
+                                                          a_make_connection); } ),
+                   DL_BIND_CALL_GUARD_STREAMS,
+                   pybind11::arg( "config"),
                    pybind11::arg( "name" ) = "",
                    pybind11::arg( "broker" ) = "",
                    pybind11::arg( "port" ) = 0,


### PR DESCRIPTION
Fixes ability to pass param_node object to config arg of C++-implemented class constructors.

Should resolve #52 