### PR TITLE
don't bind them but need valid classes

### DIFF
--- a/module_bindings/dripline_core/message_pybind.hh
+++ b/module_bindings/dripline_core/message_pybind.hh
@@ -16,14 +16,6 @@ LOGGER( dlog_mph, "message_pybind.hh" )
 
 namespace dripline_pybind
 {
-    /*
-    class _message : public dripline::message
-    {
-        public:
-            //using dripline::message::derived_modify_amqp_message;
-            //using dripline::message::derived_modify_message_param;
-    };
-    */
 
     std::list< std::string >  export_message( pybind11::module& mod )
     {
@@ -76,16 +68,6 @@ namespace dripline_pybind
             .def( "is_reply", &dripline::message::is_reply, "Returns true if the message is a reply, false otherwise" )
             .def( "is_alert", &dripline::message::is_alert, "Returns true if the message is an alert, false otherwise" )
 
-            // methods to convert between dripline message, amqp types, etc.
-            /*.def_static( "process_envelope", &dripline::message::process_envelope,
-                "From AMQP to message object" ) */
-            /*
-            .def( "derived_modify_message_param",
-                  &_message::derived_modify_message_param,
-                  "derived_modify_amqp_message function",
-                  DL_BIND_CALL_GUARD_STREAMS
-                )
-            */
 
             .def( "encode_full_message", [](const dripline::message& a_message){ return a_message.encode_full_message(4000); } )
             ;

--- a/module_bindings/dripline_core/message_pybind.hh
+++ b/module_bindings/dripline_core/message_pybind.hh
@@ -16,12 +16,14 @@ LOGGER( dlog_mph, "message_pybind.hh" )
 
 namespace dripline_pybind
 {
+    /*
     class _message : public dripline::message
     {
         public:
-            using dripline::message::derived_modify_amqp_message;
-            using dripline::message::derived_modify_message_param;
+            //using dripline::message::derived_modify_amqp_message;
+            //using dripline::message::derived_modify_message_param;
     };
+    */
 
     std::list< std::string >  export_message( pybind11::module& mod )
     {
@@ -77,11 +79,13 @@ namespace dripline_pybind
             // methods to convert between dripline message, amqp types, etc.
             /*.def_static( "process_envelope", &dripline::message::process_envelope,
                 "From AMQP to message object" ) */
+            /*
             .def( "derived_modify_message_param",
                   &_message::derived_modify_message_param,
                   "derived_modify_amqp_message function",
                   DL_BIND_CALL_GUARD_STREAMS
                 )
+            */
 
             .def( "encode_full_message", [](const dripline::message& a_message){ return a_message.encode_full_message(4000); } )
             ;

--- a/module_bindings/dripline_core/message_trampoline.hh
+++ b/module_bindings/dripline_core/message_trampoline.hh
@@ -26,6 +26,12 @@ namespace dripline_pybind
                 PYBIND11_OVERLOAD_PURE( bool, dripline::message, is_alert, );
             }
 
+            // don't know if we plan to override in python, but need this method to not be pure-virtual
+            void derived_modify_amqp_message( dripline::amqp_message_ptr a_amqp_msg, AmqpClient::Table& a_properties ) const override
+            {
+                PYBIND11_OVERLOAD_PURE( void, dripline::message, derived_modify_amqp_message, a_amqp_msg, a_properties );
+            }
+
             void derived_modify_message_param( scarab::param_node& a_node ) const override
             {
                 PYBIND11_OVERLOAD_PURE( void, dripline::message, derived_modify_message_body, a_node );


### PR DESCRIPTION
Looks like Yadi not only removed some bindings that did not belong, but left a function as virtual that needs to not be.. things build again with this.