### PR TITLE
bump base image tag to 3.7, use a variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ addons:
     - tree
 
 env:
-- DOCKER_CLI_EXPERIMENTAL=enabled
-- BASE_IMAGE_TAG="3.7"
+- DOCKER_CLI_EXPERIMENTAL=enabled BASE_IMAGE_TAG="3.7"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
 
 env:
 - DOCKER_CLI_EXPERIMENTAL=enabled
+- BASE_IMAGE_TAG="3.7"
 
 branches:
   only:
@@ -37,7 +38,7 @@ jobs:
     script:
     - set -e
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - ".travis/bootstrap_image.sh -u amd64 -r python -t 3.5 -a amd64 -i driplineorg/dripline-python:`echo
+    - ".travis/bootstrap_image.sh -u amd64 -r python -t ${BASE_IMAGE_TAG} -a amd64 -i driplineorg/dripline-python:`echo
       ${TRAVIS_BRANCH} | tr / _`"
   - stage: build images
     name: arm32v7
@@ -45,7 +46,7 @@ jobs:
     script:
     - set -e
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - ".travis/bootstrap_image.sh -u arm32v7 -r python -t 3.5 -a arm7 -i driplineorg/dripline-python:`echo
+    - ".travis/bootstrap_image.sh -u arm32v7 -r python -t ${BASE_IMAGE_TAG} -a arm7 -i driplineorg/dripline-python:`echo
       ${TRAVIS_BRANCH} | tr / _`"
 
   ## build general-use manifest


### PR DESCRIPTION
dripline-python >=4.3 requires python >=3.6, we use 3.7 for standard builds