### PR TITLE
Hotfix/hostnetwork

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,4 +4,4 @@ apiVersion: v1
 appVersion: "v4.4.2-amd64"
 description: Deploy a dripline-python microservice
 name: dripline-python
-version: 1.1.0
+version: 1.1.1

--- a/chart/templates/dripline-python-deployment.yaml
+++ b/chart/templates/dripline-python-deployment.yaml
@@ -18,6 +18,8 @@ spec:
       annotations:
         checksum/config: {{ .Values.configFileData | toYaml | sha256sum }}
     spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION

## Fixes
The flannel CNI is no longer supported. See https://github.com/kubernetes/website/commit/a9d7ba33446914de7c38adfc6825a5828facaff5

To make it work with the Calico CNI, we had to adjust the Chart to start pods with 
```
      hostNetwork: true
      dnsPolicy: ClusterFirstWithHostNet
```
I suspect that in the case of dripline, this is a good default setting. I don't suspect that it will break flannel setups that are already running.

## Testing
Tested with helm 3.2 and kubernetes 1.18.2 on bare metal. Using Calico CNI.

## Prior to merging for releases:
- [ ] update the project's version in the top-level `CMakeLists.txt` file
- [x] update the `appVersion` to be the new container image tag version in `chart/Chart.yaml`
