### PR TITLE
interate over list(kwargs.keys()) instead of kwarg.keys()

### DIFF
--- a/dripline/implementations/postgres_interface.py
+++ b/dripline/implementations/postgres_interface.py
@@ -167,7 +167,7 @@ class SQLTable(Endpoint):
         '''
         '''
         # make sure that all provided insert values are expected
-        for col in kwargs.keys():
+        for col in list(kwargs.keys()):
             if not col in self._column_map.keys():
                 logger.debug(f'got an unexpected insert column <{col}>')
                 kwargs.pop(col)


### PR DESCRIPTION

## Fixes
I was trying to insert a data value into my database, but ran into an error `RuntimeError: dictionary changed size during iteration`. Noah and [this StackOverflow entry](https://stackoverflow.com/questions/11941817/how-to-avoid-runtimeerror-dictionary-changed-size-during-iteration-error) pointed out the solution. In line 170 of postgres_interface.py, I had to change `for col in kwargs.keys():` to `for col in list(kwargs.keys()):`

I'm pasting the output of the logger when it was crashing.
```
raphaelc@nlwymmd:~/orpheus_site_atlas$ kubectl logs -f na-logger-dripline-python-deployment-6b86f95dcf-pqwgt
2020-05-15 22:01:37 [ PROG] i/application.cc(128): Final configuration:                                                                                                                                                                                                                                                                                                                         
{                                                                                                                                                                                                                                                                                                                                                                                                   dripline :
    {
        alerts-exchange : alerts
        broker : rabbitmq-app.default.svc.cluster.local                                                                                                                                                                                                                                                                                                                                                 heartbeat-interval-s : 60
        heartbeat-routing-key : heartbeat
        loop-timeout-ms : 1000
        max-payload-size : 10000
        message-wait-ms : 1000
        requests-exchange : requests
    }

    runtime-config :
2020-05-15T22:01:37[INFO    ] dripline(86) -> python got a master config:
{'dripline': {'alerts-exchange': 'alerts', 'broker': 'rabbitmq-app.default.svc.cluster.local', 'heartbeat-interval-s': 60, 'heartbeat-routing-key': 'heartbeat', 'loop-timeout-ms': 1000, 'max-payload-size': 10000, 'message-wait-ms': 1000, 'requests-exchange': 'requests'}, 'runtime-config': {'alert_key_parser_re': 'na_value\\.(?P<na_key>\\w+)', 'alert_keys': ['na_value.#'], 'auth_fil
e': '/etc/rabbitmq-secret/authentications.json', 'auths_file': '/etc/rabbitmq-secret/authentications.json', 'database_name': 'orpheus_db', 'database_server': 'postgres-orpheus-postgresql.default.svc.cluster.local', 'endpoints': [{'module': 'SQLTable', 'name': 'values_table', 'required_insert_names': ['timestamp', {'column': 'start_frequency', 'payload_key': 'na_start_freq'}], 'tabl
e_name': 'na_log'}], 'insertion_table_endpoint_name': 'values_table', 'module': 'PostgresSensorLogger', 'name': 'na_logger'}}
    {
        alert_key_parser_re : na_value\.(?P<na_key>\w+)
        alert_keys :
        [
            na_value.#
        ]

        auth_file : /etc/rabbitmq-secret/authentications.json
        auths_file : /etc/rabbitmq-secret/authentications.json
        database_name : orpheus_db
        database_server : postgres-orpheus-postgresql.default.svc.cluster.local
        endpoints :
        [

            {
                module : SQLTable
                name : values_table
                required_insert_names :
                [                                                                                                                                                                                                                                                                                                                                                                                                   timestamp

                    {
                        column : start_frequency
                        payload_key : na_start_freq
                    }

                ]

                table_name : na_log
            }

        ]

        insertion_table_endpoint_name : values_table
        module : PostgresSensorLogger
        name : na_logger                                                                                                                                                                                                                                                                                                                                                                            }

}

2020-05-15 22:01:37 [ PROG] i/application.cc(129): Ordered args:                                                                                                                                                                                                                                                                                                                                
[
]

2020-05-15T22:01:37[WARNING ] dripline.implementations.postgres_interface(51) -> you have passed an auths file directly to 'PostgreSQLInterface.__init-_', this capability is considered temporary
2020-05-15T22:01:37[INFO    ] dripline(99) -> service built                                                                                                                                                                                                                                                                                                                                     2020-05-15T22:01:37[INFO    ] dripline(110) -> about to start the service
2020-05-15T22:01:37[INFO    ] dripline(112) -> services started, now to listen
2020-05-15T22:01:52[INFO    ] dripline.implementations.postgres_sensor_logger(46) -> insert data are:
{'timestamp': '2020-05-15T22:01:52.318784Z', 'na_key': 'na_start_freq', 'value_cal': 15000000000.0, 'value_raw': '+1.50000000000E+010'}
2020-05-15 22:01:52 [ERROR] brary/service.cc(467): <na_logger> Standard exception caught while handling message: RuntimeError: dictionary changed size during iteration                                                                                                                                                                                                                         
At:                                                                                                                                                                                                                                                                                                                                                                                               /usr/local/lib/python3.7/site-packages/dripline/implementations/postgres_interface.py(170): do_insert
  /usr/local/lib/python3.7/site-packages/dripline/implementations/postgres_sensor_logger.py(48): process_payload
  /usr/local/lib/python3.7/site-packages/dripline/core/alert_consumer.py(45): on_alert_message

2020-05-15 22:01:52 [ERROR] rary/receiver.cc(399): Exception caught; shutting down.
        RuntimeError: dictionary changed size during iteration

At:
  /usr/local/lib/python3.7/site-packages/dripline/implementations/postgres_interface.py(170): do_insert
  /usr/local/lib/python3.7/site-packages/dripline/implementations/postgres_sensor_logger.py(48): process_payload
  /usr/local/lib/python3.7/site-packages/dripline/core/alert_consumer.py(45): on_alert_message
```


## Prior to merging for releases:
- [ ] update the project's version in the top-level `CMakeLists.txt` file
- [ ] update the `appVersion` to be the new container image tag version in `chart/Chart.yaml`
