### PR TITLE
added lockout_key to interface functions

### DIFF
--- a/dripline/core/interface.py
+++ b/dripline/core/interface.py
@@ -13,7 +13,7 @@ class Interface(Core):
     A class on top of dripline.core.Core with more user-friendly methods for dripline interactions.
     Intended for use as a dripline client in scripts or interactive sessions.
     '''
-    def __init__(self, dripline_config={}, confirm_retcodes=True):
+    def __init__(self, dripline_config={}, confirm_retcodes=True, lockout_key = None):
         '''
         dripline_config (dict): passed to dripline.core.Core to configure connection details
         confirm_retcodes (bool): if True and if a reply is received with retcode!=0, raise an exception
@@ -24,48 +24,59 @@ class Interface(Core):
         self._confirm_retcode = confirm_retcodes
         self._receiver = Receiver()
 
-    def _send_request(self, msgop, target, specifier=None, payload=None, timeout=None, lockout_key=False):
+    def _send_request(self, msgop, target, specifier=None, payload=None, timeout=None, lockout_key=None):
         '''
         internal helper method to standardize sending request messages
         '''
+        if not (isinstance(lockout_key, str) or lockout_key == None):
+            raise DriplineError('lockout_key needs to be a string')
         a_specifier = specifier if specifier is not None else ""
-        a_request = MsgRequest.create(payload=scarab.to_param(payload), msg_op=msgop, routing_key=target, specifier=a_specifier)
+        if lockout_key == None:
+            a_request = MsgRequest.create(payload=scarab.to_param(payload), msg_op=msgop, routing_key=target, specifier=a_specifier)
+        else:
+            a_request = MsgRequest.create(payload=scarab.to_param(payload), msg_op=msgop, routing_key=target, specifier=a_specifier, lockout_key = lockout_key)
         receive_reply = self.send(a_request)
         if not receive_reply.successful_send:
             raise DriplineError('unable to send request')
         return receive_reply
 
-    def get(self, endpoint, specifier=None, timeout=0):
+    def get(self, endpoint, specifier=None, timeout=0, lockout_key=None):
         '''
         [kw]args:
         endpoint (string): routing key to which an OP_GET will be sent
         specifier (string|None): specifier to add to the message
         '''
-        reply_pkg = self._send_request( msgop=op_t.get, target=endpoint, specifier=specifier )
+        if not (isinstance(lockout_key, str) or lockout_key == None):
+            raise DriplineError('lockout_key needs to be a string')
+        reply_pkg = self._send_request( msgop=op_t.get, target=endpoint, specifier=specifier, lockout_key = lockout_key )
         result = self._receiver.wait_for_reply(reply_pkg, timeout)
         return result
 
-    def set(self, endpoint, value, specifier=None, timeout=0):
+    def set(self, endpoint, value, specifier=None, timeout=0, lockout_key=None):
         '''
         [kw]args:
         endpoint (string): routing key to which an OP_GET will be sent
         value : value to assign
         specifier (string|None): specifier to add to the message
         '''
+        if not (isinstance(lockout_key, str) or lockout_key == None):
+            raise DriplineError('lockout_key needs to be a string')
         payload = {'values':[value]}
-        reply_pkg = self._send_request( msgop=op_t.set, target=endpoint, specifier=specifier, payload=payload )
+        reply_pkg = self._send_request( msgop=op_t.set, target=endpoint, specifier=specifier, payload=payload, lockout_key = lockout_key )
         result = self._receiver.wait_for_reply(reply_pkg, timeout)
         return result
 
-    def cmd(self, endpoint, method, ordered_args=[], keyed_args={}, timeout=0):
+    def cmd(self, endpoint, method, ordered_args=[], keyed_args={}, timeout=0, lockout_key=None):
         '''
         [kw]args:
         endpoint (string): routing key to which an OP_GET will be sent
         method (string): specifier to add to the message, naming the method to execute
         arguments (dict): dictionary of arguments to the specified method
         '''
+        if not (isinstance(lockout_key, str) or lockout_key == None):
+            raise DriplineError('lockout_key needs to be a string')
         payload = {'values': ordered_args}
         payload.update(keyed_args)
-        reply_pkg = self._send_request( msgop=op_t.cmd, target=endpoint, specifier=method, payload=payload )
+        reply_pkg = self._send_request( msgop=op_t.cmd, target=endpoint, specifier=method, payload=payload, lockout_key = lockout_key )
         result = self._receiver.wait_for_reply(reply_pkg, timeout)
         return result


### PR DESCRIPTION
I am expecting that this pull request won't get accepted. I am missing some features and I haven't tested this yet. But I'm going to ask for a pull request anyway to get feedback.

*update and add/remove sections as needed*
## New Features
Allows the python interface to recognize the lockout key.

## Fixes
I added recognition of the lockout key to the functions inside of interface.py
Related to this issue: https://github.com/driplineorg/dripline-python/issues/120

## Testing
I tested locally that the error catching probably works. I have not really tested this. There's a subtlety with type `uuid_t` that I am not equipped to handle right now. Noah said that Ben probably has to look into it.

## Prior to merging for releases:
- [ ] update the project's version in the top-level `CMakeLists.txt` file
- [ ] update the `appVersion` to be the new container image tag version in `chart/Chart.yaml`
