### PR TITLE
Pass the string representation of the exception

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project( DriplinePy VERSION 4.5.0 )
+project( DriplinePy VERSION 4.5.1 )
 
 find_package( pybind11 REQUIRED )
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 ## the appVersion is used as the container image tag for the main container in the pod from the deployment
 ## it can be overridden by a values.yaml file in image.tag
-appVersion: "v4.5.0"
+appVersion: "v4.5.1"
 description: Deploy a dripline-python microservice
 name: dripline-python
 version: 1.1.2

--- a/dripline/implementations/ethernet_scpi_service.py
+++ b/dripline/implementations/ethernet_scpi_service.py
@@ -136,7 +136,7 @@ class EthernetSCPIService(Service):
                 raise ThrowReply('resource_error_connection', "Broken ethernet socket")
             except Exception as err: ##TODO handle all exceptions, that seems questionable
                 logger.critical("Query failed after successful ethernet socket reconnect")
-                raise ThrowReply('resource_error_no_response', err)
+                raise ThrowReply('resource_error_no_response', str(err))
         finally:
             self.alock.release()
         to_return = ';'.join(data)


### PR DESCRIPTION
## Fixes
Pass the string representation of an exception in the EthernetSCPIService.  Closes #130.

## Testing
To be tested by Raphael

## Prior to merging for releases:
- [x] update the project's version in the top-level `CMakeLists.txt` file
- [x] update the `appVersion` to be the new container image tag version in `chart/Chart.yaml`
