### PR TITLE
Hotfix/4.5.5

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ jobs:
           build-args: |
             img_user=driplineorg
             img_repo=dripline-cpp
-            img_tag=v2.8.0
+            img_tag=v2.8.1
           platforms: linux/amd64
 
   release:
@@ -70,7 +70,7 @@ jobs:
           build-args: |
             img_user=driplineorg
             img_repo=dripline-cpp
-            img_tag=v2.8.0
+            img_tag=v2.8.1
           tags: ${{ steps.docker_meta.outputs.tags }}
           platforms: linux/amd64,linux/arm/v7,linux/arm64
       - name: Image digest
@@ -116,7 +116,7 @@ jobs:
           build-args: | 
             img_user=driplineorg
             img_repo=dripline-cpp
-            img_tag=v2.8.0
+            img_tag=v2.8.1
           tags: ${{ steps.docker_meta.outputs.tags }}-dev
           platforms: linux/amd64,linux/arm/v7,linux/arm64
       - name: Image digest

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -31,5 +31,5 @@ jobs:
           build-args: |
             img_user=driplineorg
             img_repo=dripline-cpp
-            img_tag=v2.8.0
+            img_tag=v2.8.1
           platforms: linux/amd64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project( DriplinePy VERSION 4.5.4 )
+project( DriplinePy VERSION 4.5.5 )
 
 cmake_policy( SET CMP0074 NEW )
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG img_user=driplineorg
 ARG img_repo=dripline-cpp
 #ARG img_tag=hotfix_2.6.2
-ARG img_tag=v2.8.0
+ARG img_tag=v2.8.1
 #ARG img_arch=arm
 
 FROM ${img_user}/${img_repo}:${img_tag}

--- a/bin/dl-serve
+++ b/bin/dl-serve
@@ -111,10 +111,17 @@ class Serve:
                 an_endpoint.start_logging()
 
         logger.info("about to start the service")
-        the_service.start()
+        if not the_service.start():
+            raise RuntimeError("There was a problem starting the service")
+
         logger.info("services started, now to listen")
-        the_service.listen()
-        the_service.stop()
+        if not the_service.listen():
+            raise RuntimeError("there was a problem listening for messages")
+
+        logger.info("stopping the service")
+        if not the_service.stop():
+            raise RuntimeError("there was a problem stopping the service")
+
 
 if __name__ == '__main__':
     the_main = scarab.MainApp()

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 ## the appVersion is used as the container image tag for the main container in the pod from the deployment
 ## it can be overridden by a values.yaml file in image.tag
-appVersion: "v4.5.4"
+appVersion: "v4.5.5"
 description: Deploy a dripline-python microservice
 name: dripline-python
 version: 1.1.2


### PR DESCRIPTION
## Fixes
* Fixes problems recognizing rabbitmq-related errors and exiting
* dl-cpp updated to v2.8.1

## Testing
* Forced rabbitmq errors result in clean exits in dl-cpp tests and kv-store stests

## Prior to merging for releases:
- [x] update the project's version in the top-level `CMakeLists.txt` file
- [x] update the `appVersion` to be the new container image tag version in `chart/Chart.yaml`
