### PR TITLE
Docker_meta workflow action needs to use dripline-python, not driplin…

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,7 +73,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v3
         with:
-          images: driplineorg/dripline-cpp
+          images: driplineorg/dripline-python
           flavor: |
             latest=auto
             suffix=${{ matrix.tag-suffix }},onlatest=true
@@ -126,7 +126,7 @@ jobs:
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: driplineorg/dripline-cpp
+          images: driplineorg/dripline-python
           tag-sha: false
           tag-semver: |
             {{raw}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project( DriplinePy VERSION 4.5.7 )
+project( DriplinePy VERSION 4.5.8 )
 
 cmake_policy( SET CMP0074 NEW )
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 ## the appVersion is used as the container image tag for the main container in the pod from the deployment
 ## it can be overridden by a values.yaml file in image.tag
-appVersion: "v4.5.7"
+appVersion: "v4.5.8"
 description: Deploy a dripline-python microservice
 name: dripline-python
 version: 1.1.2


### PR DESCRIPTION
## Fixes
* Fix repo used in the docker_meta action

## Testing
* Testing after pushes

## Prior to merging for releases:
- [x] update the project's version in the top-level `CMakeLists.txt` file
- [x] update the `appVersion` to be the new container image tag version in `chart/Chart.yaml`
