### PR TITLE
Feature/getsetcmd mixin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)  # <3.5 is deprecated by CMake
-project( DriplinePy VERSION 5.0.1 )
+project( DriplinePy VERSION 5.0.0 )
 
 cmake_policy( SET CMP0074 NEW )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)  # <3.5 is deprecated by CMake
-project( DriplinePy VERSION 5.0.0 )
+project( DriplinePy VERSION 5.0.1 )
 
 cmake_policy( SET CMP0074 NEW )
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 ## the appVersion is used as the container image tag for the main container in the pod from the deployment
 ## it can be overridden by a values.yaml file in image.tag
-appVersion: "v5.0.1"
+appVersion: "v5.0.0"
 description: Deploy a dripline-python microservice
 name: dripline-python
 version: 1.1.2

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 ## the appVersion is used as the container image tag for the main container in the pod from the deployment
 ## it can be overridden by a values.yaml file in image.tag
-appVersion: "v5.0.0"
+appVersion: "v5.0.1"
 description: Deploy a dripline-python microservice
 name: dripline-python
 version: 1.1.2

--- a/dripline/core/__init__.py
+++ b/dripline/core/__init__.py
@@ -9,6 +9,8 @@ from .endpoint import *
 from .entity import *
 from .interface import *
 from .object_creator import *
+from .request_handler import *
+from .request_sender import *
 from .return_codes import *
 from .service import *
 from .throw_reply import *

--- a/dripline/core/endpoint.py
+++ b/dripline/core/endpoint.py
@@ -3,6 +3,7 @@ __all__ = []
 import scarab
 from _dripline.core import _Endpoint
 from .throw_reply import ThrowReply
+from .request_receiver import RequestReceiver
 
 import logging
 
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 __all__.append('Endpoint')
 
 
-class Endpoint(_Endpoint):
+class Endpoint(_Endpoint, RequestReceiver):
     '''
     Base class for all objects which can be sent dripline requests.
     Every object described in a runtime configuration passed to `dl-serve` should derive from this class (either directly or indirectly).
@@ -24,86 +25,17 @@ class Endpoint(_Endpoint):
         '''
         _Endpoint.__init__(self, name)
 
-    def result_to_scarab_payload(self, result: str):
-        """
-        Intercept result values and throw error if scarab is unable to convert to param
-        TODO: Handles global Exception case, could be more specific
-        Args:
-            result (str): request message passed
-        """
-        try:
-            return scarab.to_param(result)
-        except Exception as e:
-            result_str = str(result)
-            logger.warning(f"Bad payload: [{result_str}] is not of type bool, int, float, str, or dict. Converting to str.")
-            return scarab.to_param(result_str)
+    def do_get_request(self, a_request_message): 
+        return self._do_get_request(a_request_message)
 
-    def do_get_request(self, a_request_message):
-        logger.info("in do_get_request")
-        a_specifier = a_request_message.specifier.to_string()
-        if (a_specifier):
-            logger.debug("has specifier")
-            try:
-                logger.debug(f"specifier is: {a_specifier}")
-                an_attribute = getattr(self, a_specifier)
-                logger.debug(f"attribute '{a_specifier}' value is [{an_attribute}]")
-                return a_request_message.reply(payload=self.result_to_scarab_payload(an_attribute))
-            except AttributeError as this_error:
-                raise ThrowReply('service_error_invalid_specifier',
-                                 f"endpoint {self.name} has no attribute {a_specifier}, unable to get")
-        else:
-            logger.debug('no specifier')
-            the_value = self.on_get()
-            return a_request_message.reply(payload=self.result_to_scarab_payload(the_value))
+    def do_set_request(self, a_request_message): 
+        return self._do_set_request(a_request_message)
 
-    def do_set_request(self, a_request_message):
-        a_specifier =  a_request_message.specifier.to_string()
-        try:
-            new_value = a_request_message.payload["values"][0]()
-        except Exception as err:
-            raise ThrowReply('service_error_bad_payload', f'Set called with invalid values: {err}')
-        new_value = getattr(new_value, "as_"+new_value.type())()
-        logger.debug(f'new_value is [{new_value}]')
-        if ( a_specifier ):
-            if not hasattr(self, a_specifier):
-                raise ThrowReply('service_error_invalid_specifier',
-                                 "endpoint {} has no attribute {}, unable to set".format(self.name, a_specifier))
-            setattr(self, a_specifier, new_value)
-            return a_request_message.reply()
-        else:
-            result = self.on_set(new_value)
-            return a_request_message.reply(payload=self.result_to_scarab_payload(result))
-
-    def do_cmd_request(self, a_request_message):
-        # Note: any command executed in this way must return a python data structure which is
-        #       able to be converted to a Param object (to be returned in the reply message)
-        method_name = a_request_message.specifier.to_string()
-        try:
-            method_ref = getattr(self, method_name)
-        except AttributeError as e:
-            raise ThrowReply('service_error_invalid_method',
-                             "error getting command's corresponding method: {}".format(str(e)))
-        the_kwargs = a_request_message.payload.to_python()
-        the_args = the_kwargs.pop('values', [])
-        try:
-            result = method_ref(*the_args, **the_kwargs)
-        except TypeError as e:
-            raise ThrowReply('service_error_invalid_value', 
-                             f'A TypeError occurred while calling the requested method for endpoint {self.name}: {method_name}. Values provided may be invalid.\nOriginal error: {str(e)}')
-        return a_request_message.reply(payload=self.result_to_scarab_payload(result))
-
+    def do_cmd_request(self, a_request_message): 
+        return self._do_cmd_request(a_request_message)
+    
     def on_get(self):
-        '''
-        placeholder method for getting the value of an endpoint.
-        Implementations may override to enable OP_GET operations.
-        The implementation must return a value which is able to be passed to the ParamValue constructor.
-        '''
-        raise ThrowReply('service_error_invalid_method', "{} does not implement on_get".format(self.__class__))
-
-    def on_set(self, _value):
-        '''
-        placeholder method for setting the value of an endpoint.
-        Implementations may override to enable OP_SET operations.
-        Any returned object must already be a scarab::Param object
-        '''
-        raise ThrowReply('service_error_invalid_method', "{} does not implement on_set".format(self.__class__))
+        return self._on_get()
+    
+    def on_set(self, value):
+        return self._on_set(value)

--- a/dripline/core/endpoint.py
+++ b/dripline/core/endpoint.py
@@ -22,4 +22,55 @@ class Endpoint(_Endpoint, RequestReceiver):
             name (str) : the name of the endpoint, specifies the binding key for request messages to which this object should reply
         '''
         _Endpoint.__init__(self, name)
-    
+
+    def do_get_request(self, a_request_message):
+        '''
+        Default function for handling an OP_GET request message addressed to this endpoint.
+
+        .. note: For dripline extension developers -- This function, as defined in RequestReceiver, implements the characteristic 
+        dripline-python behavior for an endpoint receiving a get request, including using the specifier to access attributes, 
+        and calling on_get() when there is no specifier.  
+        As an extension author you might typically override RequestReciever.on_get(), but leave this function alone.
+
+        .. note: For core dripline developers -- This function has to be here to correctly receive trampolined calls from 
+        the C++ base class.  It intentionally just calls the version of do_get_request() in RequestReceiver.
+
+        Args:
+            a_request_message (MsgRequest): the message receveived by this endpoint
+        '''
+
+        return RequestReceiver.do_get_request(self, a_request_message)
+
+    def do_set_request(self, a_request_message):
+        '''
+        Default function for handling an OP_SET request message addressed to this endpoint.
+
+        .. note: For dripline extension developers -- This function, as defined in RequestReceiver, implements the characteristic 
+        dripline-python behavior for an endpoint receiving a set request, including using the specifier to access attributes, 
+        and calling on_set() when there is no specifier.  
+        As an extension author you might typically override RequestReciever.on_set(), but leave this function alone.
+
+        .. note: For core dripline developers -- This function has to be here to correctly receive trampolined calls from 
+        the C++ base class.  It intentionally just calls the version of do_set_request() in RequestReceiver.
+
+        Args:
+            a_request_message (MsgRequest): the message receveived by this endpoint
+        '''
+
+        return RequestReceiver.do_set_request(self, a_request_message)
+
+    def do_cmd_request(self, a_request_message):
+        '''
+        Default function for handling an OP_CMD request message addressed to this endpoint.
+
+        .. note: For dripline extension developers -- This function, as defined in RequestReceiver, implements the characteristic 
+        dripline-python behavior for an endpoint receiving a cmd request, namesly using the specifier to call endpoint methods.
+
+        .. note: For core dripline developers -- This function has to be here to correctly receive trampolined calls from 
+        the C++ base class.  It intentionally just calls the version of do_cmd_request() in RequestReceiver.
+
+        Args:
+            a_request_message (MsgRequest): the message receveived by this endpoint
+        '''
+
+        return RequestReceiver.do_cmd_request(self, a_request_message)

--- a/dripline/core/endpoint.py
+++ b/dripline/core/endpoint.py
@@ -1,7 +1,7 @@
 __all__ = []
 
 from _dripline.core import _Endpoint
-from .request_receiver import RequestReceiver
+from .request_receiver import RequestHandler
 
 import logging
 
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 __all__.append('Endpoint')
 
 
-class Endpoint(_Endpoint, RequestReceiver):
+class Endpoint(_Endpoint, RequestHandler):
     '''
     Base class for all objects which can be sent dripline requests.
     Every object described in a runtime configuration passed to `dl-serve` should derive from this class (either directly or indirectly).
@@ -27,50 +27,50 @@ class Endpoint(_Endpoint, RequestReceiver):
         '''
         Default function for handling an OP_GET request message addressed to this endpoint.
 
-        .. note: For dripline extension developers -- This function, as defined in RequestReceiver, implements the characteristic 
+        .. note: For dripline extension developers -- This function, as defined in RequestHandler, implements the characteristic 
         dripline-python behavior for an endpoint receiving a get request, including using the specifier to access attributes, 
         and calling on_get() when there is no specifier.  
         As an extension author you might typically override RequestReciever.on_get(), but leave this function alone.
 
         .. note: For core dripline developers -- This function has to be here to correctly receive trampolined calls from 
-        the C++ base class.  It intentionally just calls the version of do_get_request() in RequestReceiver.
+        the C++ base class.  It intentionally just calls the version of do_get_request() in RequestHandler.
 
         Args:
             a_request_message (MsgRequest): the message receveived by this endpoint
         '''
 
-        return RequestReceiver.do_get_request(self, a_request_message)
+        return RequestHandler.do_get_request(self, a_request_message)
 
     def do_set_request(self, a_request_message):
         '''
         Default function for handling an OP_SET request message addressed to this endpoint.
 
-        .. note: For dripline extension developers -- This function, as defined in RequestReceiver, implements the characteristic 
+        .. note: For dripline extension developers -- This function, as defined in RequestHandler, implements the characteristic 
         dripline-python behavior for an endpoint receiving a set request, including using the specifier to access attributes, 
         and calling on_set() when there is no specifier.  
         As an extension author you might typically override RequestReciever.on_set(), but leave this function alone.
 
         .. note: For core dripline developers -- This function has to be here to correctly receive trampolined calls from 
-        the C++ base class.  It intentionally just calls the version of do_set_request() in RequestReceiver.
+        the C++ base class.  It intentionally just calls the version of do_set_request() in RequestHandler.
 
         Args:
             a_request_message (MsgRequest): the message receveived by this endpoint
         '''
 
-        return RequestReceiver.do_set_request(self, a_request_message)
+        return RequestHandler.do_set_request(self, a_request_message)
 
     def do_cmd_request(self, a_request_message):
         '''
         Default function for handling an OP_CMD request message addressed to this endpoint.
 
-        .. note: For dripline extension developers -- This function, as defined in RequestReceiver, implements the characteristic 
+        .. note: For dripline extension developers -- This function, as defined in RequestHandler, implements the characteristic 
         dripline-python behavior for an endpoint receiving a cmd request, namesly using the specifier to call endpoint methods.
 
         .. note: For core dripline developers -- This function has to be here to correctly receive trampolined calls from 
-        the C++ base class.  It intentionally just calls the version of do_cmd_request() in RequestReceiver.
+        the C++ base class.  It intentionally just calls the version of do_cmd_request() in RequestHandler.
 
         Args:
             a_request_message (MsgRequest): the message receveived by this endpoint
         '''
 
-        return RequestReceiver.do_cmd_request(self, a_request_message)
+        return RequestHandler.do_cmd_request(self, a_request_message)

--- a/dripline/core/endpoint.py
+++ b/dripline/core/endpoint.py
@@ -1,7 +1,7 @@
 __all__ = []
 
 from _dripline.core import _Endpoint
-from .request_receiver import RequestHandler
+from .request_handler import RequestHandler
 
 import logging
 

--- a/dripline/core/endpoint.py
+++ b/dripline/core/endpoint.py
@@ -1,8 +1,6 @@
 __all__ = []
 
-import scarab
 from _dripline.core import _Endpoint
-from .throw_reply import ThrowReply
 from .request_receiver import RequestReceiver
 
 import logging
@@ -24,13 +22,4 @@ class Endpoint(_Endpoint, RequestReceiver):
             name (str) : the name of the endpoint, specifies the binding key for request messages to which this object should reply
         '''
         _Endpoint.__init__(self, name)
-
-    def do_get_request(self, a_request_message): 
-        return self._do_get_request(a_request_message)
-
-    def do_set_request(self, a_request_message): 
-        return self._do_set_request(a_request_message)
-
-    def do_cmd_request(self, a_request_message): 
-        return self._do_cmd_request(a_request_message)
     

--- a/dripline/core/endpoint.py
+++ b/dripline/core/endpoint.py
@@ -34,8 +34,3 @@ class Endpoint(_Endpoint, RequestReceiver):
     def do_cmd_request(self, a_request_message): 
         return self._do_cmd_request(a_request_message)
     
-    def on_get(self):
-        return self._on_get()
-    
-    def on_set(self, value):
-        return self._on_set(value)

--- a/dripline/core/interface.py
+++ b/dripline/core/interface.py
@@ -13,6 +13,8 @@ class Interface(Core, RequestSender):
     '''
     A class that provides user-friendly methods for dripline interactions in a Python interpreter.
     Intended for use as a dripline client in scripts or interactive sessions.
+
+    See :py:class:dripline.core.RequestSender for the message-sending interface.
     '''
     def __init__(self, username: str | dict=None, password: str | dict=None, dripline_mesh: dict=None, timeout_s: int=10, confirm_retcodes: bool=True):
         '''

--- a/dripline/core/interface.py
+++ b/dripline/core/interface.py
@@ -3,12 +3,13 @@ __all__ = []
 import scarab
 
 from _dripline.core import op_t, create_dripline_auth_spec, Core, DriplineConfig, Receiver, MsgRequest, MsgReply, DriplineError
+from .request_sender import RequestSender
 
 import logging
 logger = logging.getLogger(__name__)
 
 __all__.append("Interface")
-class Interface(Core):
+class Interface(Core, RequestSender):
     '''
     A class that provides user-friendly methods for dripline interactions in a Python interpreter.
     Intended for use as a dripline client in scripts or interactive sessions.
@@ -62,93 +63,9 @@ class Interface(Core):
         auth.process_spec()
 
         Core.__init__(self, config=scarab.to_param(dripline_config), auth=auth)
+        RequestSender.__init__(self, sender=self)
 
         self._confirm_retcode = confirm_retcodes
         self.timeout_s = timeout_s
         self._receiver = Receiver()
 
-
-    def _send_request(self, msgop, target, specifier=None, payload=None, timeout=None, lockout_key=None):
-        '''
-        internal helper method to standardize sending request messages
-        '''
-        a_specifier = specifier if specifier is not None else ""
-        a_request = MsgRequest.create(payload=scarab.to_param(payload), msg_op=msgop, routing_key=target, specifier=a_specifier)
-        a_request.lockout_key = lockout_key if lockout_key is not None else ""
-        receive_reply = self.send(a_request)
-        if not receive_reply.successful_send:
-            raise DriplineError('unable to send request')
-        return receive_reply
-
-    def _receive_reply(self, reply_pkg, timeout_s):
-        '''
-        internal helper method to standardize receiving reply messages
-        '''
-        sig_handler = scarab.SignalHandler()
-        sig_handler.add_cancelable(self._receiver)
-        result = self._receiver.wait_for_reply(reply_pkg, timeout_s * 1000) # receiver expects ms
-        sig_handler.remove_cancelable(self._receiver)
-        return result
-
-    def get(self, endpoint: str, specifier: str=None, lockout_key=None, timeout_s: int=0) -> MsgReply:
-        '''
-        Send a get request to an endpoint and return the reply message.
-
-        Parameters
-        ----------
-            endpoint: str
-                Routing key to which the request should be sent.
-            specifier: str, optional
-                Specifier to add to the request, if needed.
-            timeout_s: int | float, optional
-                Maximum time to wait for a reply in seconds (default is 0)
-                A timeout of 0 seconds means no timeout will be used.
-        '''
-        reply_pkg = self._send_request( msgop=op_t.get, target=endpoint, specifier=specifier, lockout_key=lockout_key )
-        result = self._receive_reply( reply_pkg, timeout_s )
-        return result
-
-    def set(self, endpoint: str, value: str | int | float | bool, specifier: str=None, lockout_key=None, timeout_s: int | float=0) -> MsgReply:
-        '''
-        Send a set request to an endpoint and return the reply message.
-
-        Parameters
-        ----------
-            endpoint: str
-                Routing key to which the request should be sent.
-            value: str | int | float | bool
-                Value to assign in the set operation
-            specifier: str, optional
-                Specifier to add to the request, if needed.
-            timeout_s: int | float, optional
-                Maximum time to wait for a reply in seconds (default is 0)
-                A timeout of 0 seconds means no timeout will be used.
-        '''
-        payload = {'values':[value]}
-        reply_pkg = self._send_request( msgop=op_t.set, target=endpoint, specifier=specifier, payload=payload, lockout_key=lockout_key )
-        result = self._receive_reply( reply_pkg, timeout_s )
-        return result
-
-    def cmd(self, endpoint: str, specifier: str, ordered_args=None, keyed_args=None, lockout_key=None, timeout_s: int | float=0) -> MsgReply:
-        '''
-        Send a cmd request to an endpoint and return the reply message.
-
-        Parameters
-        ----------
-            endpoint: str
-                Routing key to which the request should be sent.
-            ordered_args: array, optional
-                Array of values to assign under 'values' in the payload, if any
-            keyed_args: dict, optional
-                Keyword arguments to assign to the payload, if any
-            specifier: str
-                Specifier to add to the request.  For a dripline-python endpoint, this will be the method executed.
-            timeout_s: int | float, optional
-                Maximum time to wait for a reply in seconds (default is 0)
-                A timeout of 0 seconds means no timeout will be used.
-        '''
-        payload = {'values': [] if ordered_args is None else ordered_args}
-        payload.update({} if keyed_args is None else keyed_args)
-        reply_pkg = self._send_request( msgop=op_t.cmd, target=endpoint, specifier=specifier, lockout_key=lockout_key, payload=payload )
-        result = self._receive_reply( reply_pkg, timeout_s )
-        return result

--- a/dripline/core/request_handler.py
+++ b/dripline/core/request_handler.py
@@ -8,8 +8,8 @@ from .throw_reply import ThrowReply
 import logging
 logger = logging.getLogger(__name__)
 
-__all__.append("RequestReceiver")
-class RequestReceiver():
+__all__.append("RequestHandler")
+class RequestHandler():
     '''
     A mixin class that provides methods for dripline responses in a dripline objects.
     Intended for use as a centralized object containing response methods in dripline. 
@@ -17,7 +17,7 @@ class RequestReceiver():
     This class is used by Endpoint and Service to include the dripline-standard behavior 
     for handling and responding to requests.
 
-    Any class using RequestReceiver will get the following features:
+    Any class using RequestHandler will get the following features:
 
     * When handling a get/set request that does *not* include a specifier, 
       the function ``on_[get/set]()`` will be called.

--- a/dripline/core/request_receiver.py
+++ b/dripline/core/request_receiver.py
@@ -1,0 +1,106 @@
+__all__ = []
+
+import scarab
+
+from .throw_reply import ThrowReply
+
+
+import logging
+logger = logging.getLogger(__name__)
+
+__all__.append("RequestReceiver")
+class RequestReceiver():
+    '''
+    A mixin class that provides methods for dripline responses in a dripline objects.
+    Intended for use as a centralized object containing response methods in dripline. 
+    '''
+
+    def result_to_scarab_payload(self, result: str):
+        """
+        Intercept result values and throw error if scarab is unable to convert to param
+        TODO: Handles global Exception case, could be more specific
+        Args:
+            result (str): request message passed
+        """
+        try:
+            return scarab.to_param(result)
+        except Exception as e:
+            result_str = str(result)
+            logger.warning(f"Bad payload: [{result_str}] is not of type bool, int, float, str, or dict. Converting to str.")
+            return scarab.to_param(result_str)
+
+    def _do_get_request(self, a_request_message):
+        logger.info("in get_request")
+        a_specifier = a_request_message.specifier.to_string()
+        if (a_specifier):
+            logger.debug("has specifier")
+            try:
+                logger.debug(f"specifier is: {a_specifier}")
+                an_attribute = getattr(self, a_specifier)
+                the_node = scarab.ParamNode()
+                the_node.add("values", scarab.ParamArray())
+                the_node["values"].push_back(self.result_to_scarab_payload(an_attribute))
+                logger.debug(f"attribute '{a_specifier}' value is [{an_attribute}]")
+                return a_request_message.reply(payload=the_node)
+            except AttributeError as this_error:
+                raise ThrowReply('service_error_invalid_specifier',
+                                 f"endpoint {self.name} has no attribute {a_specifier}, unable to get")
+        else:
+            logger.debug('no specifier')
+            the_value = self._on_get()
+            return a_request_message.reply(payload=self.result_to_scarab_payload(the_value))
+
+    def _do_set_request(self, a_request_message):
+
+        a_specifier = a_request_message.specifier.to_string()
+        if not "values" in a_request_message.payload:
+            raise ThrowReply('service_error_bad_payload',
+                             'setting called without values, but values are required for set')
+        new_value = a_request_message.payload["values"][0]()
+        new_value = getattr(new_value, "as_" + new_value.type())()
+        logger.debug(f'Attempting to set new_value to [{new_value}]')
+
+        if (a_specifier):
+            if not hasattr(self, a_specifier):
+                raise ThrowReply('service_error_invalid_specifier',
+                                 "endpoint {} has no attribute {}, unable to set".format(self.name, a_specifier))
+            setattr(self, a_specifier, new_value)
+            return a_request_message.reply()
+        else:
+            result = self.on_set(new_value)
+            return a_request_message.reply(payload=self.result_to_scarab_payload(result))
+
+    def _do_cmd_request(self, a_request_message):
+        # Note: any command executed in this way must return a python data structure which is
+        #       able to be converted to a Param object (to be returned in the reply message)
+        method_name = a_request_message.specifier.to_string()
+        try:
+            method_ref = getattr(self, method_name)
+        except AttributeError as e:
+            raise ThrowReply('service_error_invalid_method',
+                             "error getting command's corresponding method: {}".format(str(e)))
+        the_kwargs = a_request_message.payload.to_python()
+        the_args = the_kwargs.pop('values', [])
+        print(f'args: {the_args} -- kwargs: {the_kwargs}')
+        try:
+            result = method_ref(*the_args, **the_kwargs)
+        except TypeError as e:
+            raise ThrowReply('service_error_invalid_value', 
+                             f'A TypeError occurred while calling the requested method for endpoint {self.name}: {method_name}. Values provided may be invalid.\nOriginal error: {str(e)}')
+        return a_request_message.reply(payload=self.result_to_scarab_payload(result))
+
+    def _on_get(self):
+        '''
+        placeholder method for getting the value of an endpoint.
+        Implementations may override to enable OP_GET operations.
+        The implementation must return a value which is able to be passed to the ParamValue constructor.
+        '''
+        raise ThrowReply('service_error_invalid_method', "{} does not implement on_get".format(self.__class__))
+
+    def _on_set(self, _value):
+        '''
+        placeholder method for setting the value of an endpoint.
+        Implementations may override to enable OP_SET operations.
+        Any returned object must already be a scarab::Param object
+        '''
+        raise ThrowReply('service_error_invalid_method', "{} does not implement on_set".format(self.__class__))

--- a/dripline/core/request_receiver.py
+++ b/dripline/core/request_receiver.py
@@ -47,7 +47,7 @@ class RequestReceiver():
                                  f"endpoint {self.name} has no attribute {a_specifier}, unable to get")
         else:
             logger.debug('no specifier')
-            the_value = self._on_get()
+            the_value = self.on_get()
             return a_request_message.reply(payload=self.result_to_scarab_payload(the_value))
 
     def _do_set_request(self, a_request_message):
@@ -89,7 +89,7 @@ class RequestReceiver():
                              f'A TypeError occurred while calling the requested method for endpoint {self.name}: {method_name}. Values provided may be invalid.\nOriginal error: {str(e)}')
         return a_request_message.reply(payload=self.result_to_scarab_payload(result))
 
-    def _on_get(self):
+    def on_get(self):
         '''
         placeholder method for getting the value of an endpoint.
         Implementations may override to enable OP_GET operations.
@@ -97,7 +97,7 @@ class RequestReceiver():
         '''
         raise ThrowReply('service_error_invalid_method', "{} does not implement on_get".format(self.__class__))
 
-    def _on_set(self, _value):
+    def on_set(self, _value):
         '''
         placeholder method for setting the value of an endpoint.
         Implementations may override to enable OP_SET operations.

--- a/dripline/core/request_receiver.py
+++ b/dripline/core/request_receiver.py
@@ -74,11 +74,13 @@ class RequestReceiver():
         # Note: any command executed in this way must return a python data structure which is
         #       able to be converted to a Param object (to be returned in the reply message)
         method_name = a_request_message.specifier.to_string()
+        if method_name == "":
+            raise ThrowReply('service_error_invalid_method', 'No specifier was provided for an OP_CMD request')
         try:
             method_ref = getattr(self, method_name)
         except AttributeError as e:
             raise ThrowReply('service_error_invalid_method',
-                             "error getting command's corresponding method: {}".format(str(e)))
+                             f'error getting command\'s corresponding method: {str(e)}')
         the_kwargs = a_request_message.payload.to_python()
         the_args = the_kwargs.pop('values', [])
         print(f'args: {the_args} -- kwargs: {the_kwargs}')
@@ -91,16 +93,16 @@ class RequestReceiver():
 
     def on_get(self):
         '''
-        placeholder method for getting the value of an endpoint.
-        Implementations may override to enable OP_GET operations.
-        The implementation must return a value which is able to be passed to the ParamValue constructor.
+        Placeholder method for getting the value of an endpoint.
+        Implementations should override to enable OP_GET operations.
+        The implementation must return a value which is convertible to a scarab param object.
         '''
         raise ThrowReply('service_error_invalid_method', "{} does not implement on_get".format(self.__class__))
 
     def on_set(self, _value):
         '''
-        placeholder method for setting the value of an endpoint.
-        Implementations may override to enable OP_SET operations.
+        Placeholder method for setting the value of an endpoint.
+        Implementations should override to enable OP_SET operations.
         Any returned object must already be a scarab::Param object
         '''
         raise ThrowReply('service_error_invalid_method', "{} does not implement on_set".format(self.__class__))

--- a/dripline/core/request_sender.py
+++ b/dripline/core/request_sender.py
@@ -33,10 +33,12 @@ class RequestSender():
         self._receiver = Receiver()
 
 
-    def _check_lockout_key(self, lockout_key:str=None):
+    def _check_lockout_key(self, lockout_key:str | uuid.UUID =None):
         nilkey = uuid.UUID('00000000-0000-0000-0000-000000000000')
         if lockout_key is None:
             return nilkey
+        if type(lockout_key) == uuid.UUID:
+            return lockout_key
         try:
             return uuid.UUID(lockout_key)
         except ValueError:

--- a/dripline/core/request_sender.py
+++ b/dripline/core/request_sender.py
@@ -2,8 +2,9 @@ __all__ = []
 
 import scarab
 
-from _dripline.core import op_t, create_dripline_auth_spec, Core, DriplineConfig, Receiver, MsgRequest, MsgReply, DriplineError
+from _dripline.core import op_t, Core, Receiver, MsgRequest, MsgReply, DriplineError
 
+import uuid
 import logging
 logger = logging.getLogger(__name__)
 
@@ -32,13 +33,24 @@ class RequestSender():
         self._receiver = Receiver()
 
 
+    def _check_lockout_key(self, lockout_key:str=None):
+        nilkey = uuid.UUID('00000000-0000-0000-0000-000000000000')
+        if lockout_key is None:
+            return nilkey
+        try:
+            return uuid.UUID(lockout_key)
+        except ValueError:
+            logger.warning("Lockout Key '{}' is not properly uuid formatted. Defaulting to nilkey. ".format(lockout_key))
+            return nilkey
+
+
     def _send_request(self, msgop, target, specifier=None, payload=None, timeout=None, lockout_key=None):
         '''
         internal helper method to standardize sending request messages
         '''
         a_specifier = specifier if specifier is not None else ""
         a_request = MsgRequest.create(payload=scarab.to_param(payload), msg_op=msgop, routing_key=target, specifier=a_specifier)
-        a_request.lockout_key = lockout_key if lockout_key is not None else ""
+        a_request.lockout_key = self._check_lockout_key(lockout_key)
         receive_reply = self.sender.send(a_request)
         if not receive_reply.successful_send:
             raise DriplineError('unable to send request')
@@ -52,7 +64,7 @@ class RequestSender():
         sig_handler.add_cancelable(self._receiver)
         result = self._receiver.wait_for_reply(reply_pkg, timeout_s * 1000) # receiver expects ms
         sig_handler.remove_cancelable(self._receiver)
-        return result
+        return result.payload.to_python()
 
     def get(self, endpoint: str, specifier: str=None, lockout_key=None, timeout_s: int=0) -> MsgReply:
         '''

--- a/dripline/core/request_sender.py
+++ b/dripline/core/request_sender.py
@@ -13,14 +13,14 @@ class RequestSender():
     A mixin class that provides convenient methods for dripline interactions in a dripline objects.
     Intended for use as a dripline client in scripts or interactive sessions.
     '''
-    def __init__(self, sender: Core, timeout_s: int=10, confirm_retcodes: bool=True):
+    def __init__(self, sender, timeout_s: int=10, confirm_retcodes: bool=True):
         '''
         Configures an interface with the necessary parameters.
 
         Parameters
         ----------
-            sender : Core
-                Provide a Core object which will use this mixin. This object will be the one to actually send the messages as it implements the Core functions
+            sender : Core, Service, or other class that implements send(MsgRequest)
+                Provide an object that will actually send the messages as it implements the send() function
             timeout_s: int, optional
                 Time to wait for a reply, in seconds -- default is 10 s
             confirm_retcodes: bool, optional  

--- a/dripline/core/request_sender.py
+++ b/dripline/core/request_sender.py
@@ -1,0 +1,118 @@
+__all__ = []
+
+import scarab
+
+from _dripline.core import op_t, create_dripline_auth_spec, Core, DriplineConfig, Receiver, MsgRequest, MsgReply, DriplineError
+
+import logging
+logger = logging.getLogger(__name__)
+
+__all__.append("RequestSender")
+class RequestSender():
+    '''
+    A mixin class that provides convenient methods for dripline interactions in a dripline objects.
+    Intended for use as a dripline client in scripts or interactive sessions.
+    '''
+    def __init__(self, sender: Core, timeout_s: int=10, confirm_retcodes: bool=True):
+        '''
+        Configures an interface with the necessary parameters.
+
+        Parameters
+        ----------
+            sender : Core
+                Provide a Core object which will use this mixin. This object will be the one to actually send the messages as it implements the Core functions
+            timeout_s: int, optional
+                Time to wait for a reply, in seconds -- default is 10 s
+            confirm_retcodes: bool, optional  
+                If True, and if a reply is received with retcode != 0, raises an exception -- default is True          
+        '''
+        self.sender = sender
+        self._confirm_retcode = confirm_retcodes
+        self.timeout_s = timeout_s
+        self._receiver = Receiver()
+
+
+    def _send_request(self, msgop, target, specifier=None, payload=None, timeout=None, lockout_key=None):
+        '''
+        internal helper method to standardize sending request messages
+        '''
+        a_specifier = specifier if specifier is not None else ""
+        a_request = MsgRequest.create(payload=scarab.to_param(payload), msg_op=msgop, routing_key=target, specifier=a_specifier)
+        a_request.lockout_key = lockout_key if lockout_key is not None else ""
+        receive_reply = self.sender.send(a_request)
+        if not receive_reply.successful_send:
+            raise DriplineError('unable to send request')
+        return receive_reply
+
+    def _receive_reply(self, reply_pkg, timeout_s):
+        '''
+        internal helper method to standardize receiving reply messages
+        '''
+        sig_handler = scarab.SignalHandler()
+        sig_handler.add_cancelable(self._receiver)
+        result = self._receiver.wait_for_reply(reply_pkg, timeout_s * 1000) # receiver expects ms
+        sig_handler.remove_cancelable(self._receiver)
+        return result
+
+    def get(self, endpoint: str, specifier: str=None, lockout_key=None, timeout_s: int=0) -> MsgReply:
+        '''
+        Send a get request to an endpoint and return the reply message.
+
+        Parameters
+        ----------
+            endpoint: str
+                Routing key to which the request should be sent.
+            specifier: str, optional
+                Specifier to add to the request, if needed.
+            timeout_s: int | float, optional
+                Maximum time to wait for a reply in seconds (default is 0)
+                A timeout of 0 seconds means no timeout will be used.
+        '''
+        reply_pkg = self._send_request( msgop=op_t.get, target=endpoint, specifier=specifier, lockout_key=lockout_key )
+        result = self._receive_reply( reply_pkg, timeout_s )
+        return result
+
+    def set(self, endpoint: str, value: str | int | float | bool, specifier: str=None, lockout_key=None, timeout_s: int | float=0) -> MsgReply:
+        '''
+        Send a set request to an endpoint and return the reply message.
+
+        Parameters
+        ----------
+            endpoint: str
+                Routing key to which the request should be sent.
+            value: str | int | float | bool
+                Value to assign in the set operation
+            specifier: str, optional
+                Specifier to add to the request, if needed.
+            timeout_s: int | float, optional
+                Maximum time to wait for a reply in seconds (default is 0)
+                A timeout of 0 seconds means no timeout will be used.
+        '''
+        payload = {'values':[value]}
+        reply_pkg = self._send_request( msgop=op_t.set, target=endpoint, specifier=specifier, payload=payload, lockout_key=lockout_key )
+        result = self._receive_reply( reply_pkg, timeout_s )
+        return result
+
+    def cmd(self, endpoint: str, specifier: str, ordered_args=None, keyed_args=None, lockout_key=None, timeout_s: int | float=0) -> MsgReply:
+        '''
+        Send a cmd request to an endpoint and return the reply message.
+
+        Parameters
+        ----------
+            endpoint: str
+                Routing key to which the request should be sent.
+            ordered_args: array, optional
+                Array of values to assign under 'values' in the payload, if any
+            keyed_args: dict, optional
+                Keyword arguments to assign to the payload, if any
+            specifier: str
+                Specifier to add to the request.  For a dripline-python endpoint, this will be the method executed.
+            timeout_s: int | float, optional
+                Maximum time to wait for a reply in seconds (default is 0)
+                A timeout of 0 seconds means no timeout will be used.
+        '''
+        payload = {'values': [] if ordered_args is None else ordered_args}
+        payload.update({} if keyed_args is None else keyed_args)
+        reply_pkg = self._send_request( msgop=op_t.cmd, target=endpoint, specifier=specifier, lockout_key=lockout_key, payload=payload )
+        result = self._receive_reply( reply_pkg, timeout_s )
+        return result

--- a/dripline/core/service.py
+++ b/dripline/core/service.py
@@ -5,6 +5,7 @@ from _dripline.core import _Service, DriplineConfig, create_dripline_auth_spec
 from .throw_reply import ThrowReply
 from .object_creator import ObjectCreator
 from .request_sender import RequestSender
+from .request_receiver import RequestReceiver
 
 import datetime
 import logging
@@ -12,7 +13,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 __all__.append('Service')
-class Service(_Service, ObjectCreator, RequestSender):
+class Service(_Service, ObjectCreator, RequestSender, RequestReceiver):
     '''
     The primary unit of software that connects to a broker and typically provides an interface with an instrument or other software.
 
@@ -130,7 +131,6 @@ class Service(_Service, ObjectCreator, RequestSender):
             auth.process_spec()
 
         _Service.__init__(self, config=scarab.to_param(config), auth=auth, make_connection=make_connection)
-
         RequestSender.__init__(self, sender=self)
 
         # Endpoints
@@ -149,91 +149,18 @@ class Service(_Service, ObjectCreator, RequestSender):
                 if getattr(an_endpoint, 'log_interval', datetime.timedelta(seconds=0)) > datetime.timedelta(seconds=0):
                     logger.debug("queue up start logging for '{}'".format(an_endpoint.name))
                     an_endpoint.start_logging()
+    
+    def do_get_request(self, a_request_message): 
+        return self._do_get_request(a_request_message)
 
+    def do_set_request(self, a_request_message): 
+        return self._do_set_request(a_request_message)
 
-    def result_to_scarab_payload(self, result: str):
-        """
-        Intercept result values and throw error if scarab is unable to convert to param
-        TODO: Handles global Exception case, could be more specific
-        Args:
-            result (str): request message passed
-        """
-        try:
-            return scarab.to_param(result)
-        except Exception as e:
-            result_str = str(result)
-            logger.warning(f"Bad payload: [{result_str}] is not of type bool, int, float, str, or dict. Converting to str.")
-            return scarab.to_param(result_str)
-
-    def do_get_request(self, a_request_message):
-        logger.info("in get_request")
-        a_specifier = a_request_message.specifier.to_string()
-        if (a_specifier):
-            logger.debug("has specifier")
-            try:
-                logger.debug(f"specifier is: {a_specifier}")
-                an_attribute = getattr(self, a_specifier)
-                logger.debug(f"attribute '{a_specifier}' value is [{an_attribute}]")
-                return a_request_message.reply(payload=self.result_to_scarab_payload(an_attribute))
-            except AttributeError as this_error:
-                raise ThrowReply('service_error_invalid_specifier',
-                                 f"endpoint {self.name} has no attribute {a_specifier}, unable to get")
-        else:
-            logger.debug('no specifier')
-            the_value = self.on_get()
-            return a_request_message.reply(payload=self.result_to_scarab_payload(the_value))
-
-    def do_set_request(self, a_request_message):
-
-        a_specifier = a_request_message.specifier.to_string()
-        if not "values" in a_request_message.payload:
-            raise ThrowReply('service_error_bad_payload',
-                             'setting called without values, but values are required for set')
-        new_value = a_request_message.payload["values"][0]()
-        new_value = getattr(new_value, "as_" + new_value.type())()
-        logger.debug(f'Attempting to set new_value to [{new_value}]')
-
-        if (a_specifier):
-            if not hasattr(self, a_specifier):
-                raise ThrowReply('service_error_invalid_specifier',
-                                 "endpoint {} has no attribute {}, unable to set".format(self.name, a_specifier))
-            setattr(self, a_specifier, new_value)
-            return a_request_message.reply()
-        else:
-            result = self.on_set(new_value)
-            return a_request_message.reply(payload=self.result_to_scarab_payload(result))
-
-    def do_cmd_request(self, a_request_message):
-        # Note: any command executed in this way must return a python data structure which is
-        #       able to be converted to a Param object (to be returned in the reply message)
-        method_name = a_request_message.specifier.to_string()
-        try:
-            method_ref = getattr(self, method_name)
-        except AttributeError as e:
-            raise ThrowReply('service_error_invalid_method',
-                             "error getting command's corresponding method: {}".format(str(e)))
-        the_kwargs = a_request_message.payload.to_python()
-        the_args = the_kwargs.pop('values', [])
-        print(f'args: {the_args} -- kwargs: {the_kwargs}')
-        try:
-            result = method_ref(*the_args, **the_kwargs)
-        except TypeError as e:
-            raise ThrowReply('service_error_invalid_value', 
-                             f'A TypeError occurred while calling the requested method for endpoint {self.name}: {method_name}. Values provided may be invalid.\nOriginal error: {str(e)}')
-        return a_request_message.reply(payload=self.result_to_scarab_payload(result))
-
+    def do_cmd_request(self, a_request_message): 
+        return self._do_cmd_request(a_request_message)
+    
     def on_get(self):
-        '''
-        placeholder method for getting the value of an endpoint.
-        Implementations may override to enable OP_GET operations.
-        The implementation must return a value which is able to be passed to the ParamValue constructor.
-        '''
-        raise ThrowReply('service_error_invalid_method', "{} does not implement on_get".format(self.__class__))
-
-    def on_set(self, _value):
-        '''
-        placeholder method for setting the value of an endpoint.
-        Implementations may override to enable OP_SET operations.
-        Any returned object must already be a scarab::Param object
-        '''
-        raise ThrowReply('service_error_invalid_method', "{} does not implement on_set".format(self.__class__))
+        return self._on_get()
+    
+    def on_set(self, value):
+        return self._on_set(value)

--- a/dripline/core/service.py
+++ b/dripline/core/service.py
@@ -4,6 +4,7 @@ import scarab
 from _dripline.core import _Service, DriplineConfig, create_dripline_auth_spec
 from .throw_reply import ThrowReply
 from .object_creator import ObjectCreator
+from .request_sender import RequestSender
 
 import datetime
 import logging
@@ -11,7 +12,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 __all__.append('Service')
-class Service(_Service, ObjectCreator):
+class Service(_Service, ObjectCreator, RequestSender):
     '''
     The primary unit of software that connects to a broker and typically provides an interface with an instrument or other software.
 
@@ -129,6 +130,8 @@ class Service(_Service, ObjectCreator):
             auth.process_spec()
 
         _Service.__init__(self, config=scarab.to_param(config), auth=auth, make_connection=make_connection)
+
+        RequestSender.__init__(self, sender=self)
 
         # Endpoints
         self.endpoint_configs = endpoints

--- a/dripline/core/service.py
+++ b/dripline/core/service.py
@@ -5,7 +5,7 @@ from _dripline.core import _Service, DriplineConfig, create_dripline_auth_spec
 from .throw_reply import ThrowReply
 from .object_creator import ObjectCreator
 from .request_sender import RequestSender
-from .request_receiver import RequestReceiver
+from .request_receiver import RequestHandler
 
 import datetime
 import logging
@@ -13,7 +13,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 __all__.append('Service')
-class Service(_Service, ObjectCreator, RequestSender, RequestReceiver):
+class Service(_Service, ObjectCreator, RequestSender, RequestHandler):
     '''
     The primary unit of software that connects to a broker and typically provides an interface with an instrument or other software.
 

--- a/dripline/core/service.py
+++ b/dripline/core/service.py
@@ -173,10 +173,7 @@ class Service(_Service, ObjectCreator, RequestSender):
                 logger.debug(f"specifier is: {a_specifier}")
                 an_attribute = getattr(self, a_specifier)
                 logger.debug(f"attribute '{a_specifier}' value is [{an_attribute}]")
-                the_node = scarab.ParamNode()
-                the_node["values"] = scarab.ParamArray()
-                the_node["values"].push_back(scarab.ParamValue(an_attribute))
-                return a_request_message.reply(payload=the_node)
+                return a_request_message.reply(payload=scarab.ParamValue(an_attribute))
             except AttributeError as this_error:
                 raise ThrowReply('service_error_invalid_specifier',
                                  f"endpoint {self.name} has no attribute {a_specifier}, unable to get")

--- a/dripline/core/service.py
+++ b/dripline/core/service.py
@@ -159,8 +159,3 @@ class Service(_Service, ObjectCreator, RequestSender, RequestReceiver):
     def do_cmd_request(self, a_request_message): 
         return self._do_cmd_request(a_request_message)
     
-    def on_get(self):
-        return self._on_get()
-    
-    def on_set(self, value):
-        return self._on_set(value)

--- a/dripline/core/service.py
+++ b/dripline/core/service.py
@@ -5,7 +5,7 @@ from _dripline.core import _Service, DriplineConfig, create_dripline_auth_spec
 from .throw_reply import ThrowReply
 from .object_creator import ObjectCreator
 from .request_sender import RequestSender
-from .request_receiver import RequestHandler
+from .request_handler import RequestHandler
 
 import datetime
 import logging

--- a/dripline/core/service.py
+++ b/dripline/core/service.py
@@ -161,8 +161,9 @@ class Service(_Service, ObjectCreator, RequestSender):
         try:
             return scarab.to_param(result)
         except Exception as e:
-            raise ThrowReply('service_error_bad_payload',
-                             f"{self.name} unable to convert result to scarab payload: {result}")
+            result_str = str(result)
+            logger.warning(f"Bad payload: [{result_str}] is not of type bool, int, float, str, or dict. Converting to str.")
+            return scarab.to_param(result_str)
 
     def do_get_request(self, a_request_message):
         logger.info("in get_request")
@@ -173,7 +174,7 @@ class Service(_Service, ObjectCreator, RequestSender):
                 logger.debug(f"specifier is: {a_specifier}")
                 an_attribute = getattr(self, a_specifier)
                 logger.debug(f"attribute '{a_specifier}' value is [{an_attribute}]")
-                return a_request_message.reply(payload=scarab.ParamValue(an_attribute))
+                return a_request_message.reply(payload=self.result_to_scarab_payload(an_attribute))
             except AttributeError as this_error:
                 raise ThrowReply('service_error_invalid_specifier',
                                  f"endpoint {self.name} has no attribute {a_specifier}, unable to get")

--- a/module_bindings/dripline_core/_service_pybind.hh
+++ b/module_bindings/dripline_core/_service_pybind.hh
@@ -41,6 +41,28 @@ namespace dripline_pybind
             .def_property( "auth", (scarab::authentication& (dripline::service::*)()) &dripline::service::auth, 
                            [](_service& a_service, const scarab::authentication& a_auth){a_service.auth() = a_auth;}, 
                            pybind11::return_value_policy::reference_internal )
+
+            // Notes on send() bindings
+            // The Service.send() functions are useful because they set the sender service name in the message before sending.
+            // The bound functions use lambdas because the dripline::service functions include amqp_ptr_t arguments which aren't known to pybind11.
+            //   Therefore when called from Python, the send process will use the default parameter, a new AMQP connection.
+            // The bindings to these functions are not included in the trampoline class because we're not directly overriding the C++ send() functions.
+            .def( "send",
+                  [](dripline::service& a_service, dripline::request_ptr_t a_request){return a_service.send(a_request);},
+                  DL_BIND_CALL_GUARD_STREAMS_AND_GIL,
+                  "send a request message"
+                )
+            .def( "send",
+                  [](dripline::service& a_service, dripline::reply_ptr_t a_reply){return a_service.send(a_reply);},
+                  DL_BIND_CALL_GUARD_STREAMS_AND_GIL,
+                  "send a reply message"
+                )
+            .def( "send",
+                  [](dripline::service& a_service, dripline::alert_ptr_t an_alert){return a_service.send(an_alert);},
+                  DL_BIND_CALL_GUARD_STREAMS_AND_GIL,
+                  "send an alert message"
+                )
+          
             .def_property( "enable_scheduling", &dripline::service::get_enable_scheduling, &dripline::service::set_enable_scheduling )
             .def_property_readonly( "alerts_exchange", (std::string& (dripline::service::*)()) &dripline::service::alerts_exchange )
             .def_property_readonly( "requests_exchange", (std::string& (dripline::service::*)()) &dripline::service::requests_exchange )

--- a/module_bindings/dripline_core/_service_trampoline.hh
+++ b/module_bindings/dripline_core/_service_trampoline.hh
@@ -21,7 +21,7 @@ namespace dripline_pybind
 
     };
 
-    class _service_trampoline : public _service
+    class _service_trampoline : public dripline::service
     {
         public:
             using _service::_service; //inherit constructors
@@ -30,41 +30,41 @@ namespace dripline_pybind
             // Local overrides
             bool bind_keys() override
             {
-                PYBIND11_OVERRIDE( bool, _service, bind_keys, );
+                PYBIND11_OVERRIDE( bool, dripline::service, bind_keys, );
             }
 
             void run() override
             {
-                PYBIND11_OVERRIDE( void, _service, run, );
+                PYBIND11_OVERRIDE( void, dripline::service, run, );
             }
 
             //// Overrides from Endpoint
             // Overrides for virtual on_[messgate-type]_message()
             dripline::reply_ptr_t on_request_message( const dripline::request_ptr_t a_request ) override
             {
-                PYBIND11_OVERRIDE( dripline::reply_ptr_t, _service, on_request_message, a_request );
+                PYBIND11_OVERRIDE( dripline::reply_ptr_t, dripline::service, on_request_message, a_request );
             }
             void on_reply_message( const dripline::reply_ptr_t a_reply ) override
             {
-                PYBIND11_OVERRIDE( void, _service, on_reply_message, a_reply );
+                PYBIND11_OVERRIDE( void, dripline::service, on_reply_message, a_reply );
             }
             void on_alert_message( const dripline::alert_ptr_t a_alert ) override
             {
-                PYBIND11_OVERRIDE( void, _service, on_alert_message, a_alert );
+                PYBIND11_OVERRIDE( void, dripline::service, on_alert_message, a_alert );
             }
 
             // Overrides for virtual do_[request-type]_request
             dripline::reply_ptr_t do_get_request( const dripline::request_ptr_t a_request ) override
             {
-                PYBIND11_OVERRIDE( dripline::reply_ptr_t, _service, do_get_request, a_request );
+                PYBIND11_OVERRIDE( dripline::reply_ptr_t, dripline::service, do_get_request, a_request );
             }
             dripline::reply_ptr_t do_set_request( const dripline::request_ptr_t a_request ) override
             {
-                PYBIND11_OVERRIDE( dripline::reply_ptr_t, _service, do_set_request, a_request );
+                PYBIND11_OVERRIDE( dripline::reply_ptr_t, dripline::service, do_set_request, a_request );
             }
             dripline::reply_ptr_t do_cmd_request( const dripline::request_ptr_t a_request ) override
             {
-                PYBIND11_OVERRIDE( dripline::reply_ptr_t, _service, do_cmd_request, a_request );
+                PYBIND11_OVERRIDE( dripline::reply_ptr_t, dripline::service, do_cmd_request, a_request );
             }
 
     };

--- a/module_bindings/dripline_core/_service_trampoline.hh
+++ b/module_bindings/dripline_core/_service_trampoline.hh
@@ -21,50 +21,50 @@ namespace dripline_pybind
 
     };
 
-    class _service_trampoline : public dripline::service
+    class _service_trampoline : public _service
     {
         public:
             using _service::_service; //inherit constructors
-            _service_trampoline(_service &&base) : _service(std::move(base)) {}
+            //_service_trampoline(_service &&base) : _service(std::move(base)) {}
 
             // Local overrides
             bool bind_keys() override
             {
-                PYBIND11_OVERRIDE( bool, dripline::service, bind_keys, );
+                PYBIND11_OVERRIDE( bool, _service, bind_keys, );
             }
 
             void run() override
             {
-                PYBIND11_OVERRIDE( void, dripline::service, run, );
+                PYBIND11_OVERRIDE( void, _service, run, );
             }
 
             //// Overrides from Endpoint
             // Overrides for virtual on_[messgate-type]_message()
             dripline::reply_ptr_t on_request_message( const dripline::request_ptr_t a_request ) override
             {
-                PYBIND11_OVERRIDE( dripline::reply_ptr_t, dripline::service, on_request_message, a_request );
+                PYBIND11_OVERRIDE( dripline::reply_ptr_t, _service, on_request_message, a_request );
             }
             void on_reply_message( const dripline::reply_ptr_t a_reply ) override
             {
-                PYBIND11_OVERRIDE( void, dripline::service, on_reply_message, a_reply );
+                PYBIND11_OVERRIDE( void, _service, on_reply_message, a_reply );
             }
             void on_alert_message( const dripline::alert_ptr_t a_alert ) override
             {
-                PYBIND11_OVERRIDE( void, dripline::service, on_alert_message, a_alert );
+                PYBIND11_OVERRIDE( void, _service, on_alert_message, a_alert );
             }
 
             // Overrides for virtual do_[request-type]_request
             dripline::reply_ptr_t do_get_request( const dripline::request_ptr_t a_request ) override
             {
-                PYBIND11_OVERRIDE( dripline::reply_ptr_t, dripline::service, do_get_request, a_request );
+                PYBIND11_OVERRIDE( dripline::reply_ptr_t, _service, do_get_request, a_request );
             }
             dripline::reply_ptr_t do_set_request( const dripline::request_ptr_t a_request ) override
             {
-                PYBIND11_OVERRIDE( dripline::reply_ptr_t, dripline::service, do_set_request, a_request );
+                PYBIND11_OVERRIDE( dripline::reply_ptr_t, _service, do_set_request, a_request );
             }
             dripline::reply_ptr_t do_cmd_request( const dripline::request_ptr_t a_request ) override
             {
-                PYBIND11_OVERRIDE( dripline::reply_ptr_t, dripline::service, do_cmd_request, a_request );
+                PYBIND11_OVERRIDE( dripline::reply_ptr_t, _service, do_cmd_request, a_request );
             }
 
     };

--- a/module_bindings/dripline_core/core_pybind.hh
+++ b/module_bindings/dripline_core/core_pybind.hh
@@ -42,6 +42,11 @@ namespace dripline_pybind
                   pybind11::arg( "make_connection" ) = true
                 )
 
+            // Notes on send() bindings
+            // The bound functions use lambdas because the dripline::core functions include amqp_ptr_t arguments which aren't known to pybind11.
+            //   Therefore when called from Python, the send process will use the default parameter, a new AMQP connection.
+            // The bindings to these functions are not included in a trampoline class because we're not directly overriding the C++ send() functions.
+            //   Therefore calls to send() from a base-class pointer will not redirect appropriately to the derived-class versions of send().
             .def( "send",
                   [](dripline::core& a_core, dripline::request_ptr_t a_request){return a_core.send(a_request);},
                   DL_BIND_CALL_GUARD_STREAMS_AND_GIL,

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -1,5 +1,7 @@
 import scarab, dripline.core
 
+import pytest
+
 def test_endpoint_creation():
     a_name = "an_endpoint"
     an_endpoint = dripline.core.Endpoint(a_name)
@@ -28,43 +30,27 @@ def test_on_request_message():
 def test_on_reply_message():
     an_endpoint = dripline.core.Endpoint("hello")
     a_reply = dripline.core.MsgReply.create()
-    print(a_reply)
-    flag = False
-    try:
+    with pytest.raises(dripline.core.DriplineError) as excinfo:
         an_endpoint.on_reply_message(a_reply)
-    except Exception: # seems like this is not throwing an actual DriplineError, just a generic Exception. dripline.core.DriplineError
-        flag = True
-    assert(flag)
 
 def test_on_alert_message():
     an_endpoint = dripline.core.Endpoint("hello")
     an_alert = dripline.core.MsgAlert.create()
-    flag = False
-    try:
+    with pytest.raises(dripline.core.DriplineError) as excinfo:
         an_endpoint.on_alert_message(an_alert)
-    except Exception: # seems like this is not throwing an actual DriplineError, just a generic Exception. dripline.core.DriplineError
-        flag =True
-    assert(flag)
 
 def test_do_get_request_no_specifier():
     an_endpoint = dripline.core.Endpoint("hello")
     a_get_request = dripline.core.MsgRequest.create()
     flag = False
-    try:
+    with pytest.raises(dripline.core.ThrowReply) as excinfo:
         a_reply = an_endpoint.do_get_request(a_get_request)
-    except dripline.core.ThrowReply:
-        flag = True
-    assert(flag)
 
 def test_do_get_request_invalid_specifier():
     an_endpoint = dripline.core.Endpoint("an_endpoint")
     a_get_request = dripline.core.MsgRequest.create(scarab.ParamValue(5), dripline.core.op_t.get, "hey", "namee", "a_receiver")
-    correct_error = False
-    try:
+    with pytest.raises(dripline.core.ThrowReply) as excinfo:
         a_reply = an_endpoint.do_get_request(a_get_request)
-    except dripline.core.ThrowReply as e:
-        correct_error = True
-    assert(correct_error)
 
 def test_do_get_request_valid_specifier():
     a_name = "an_endpoint"
@@ -83,12 +69,8 @@ def test_do_set_request_no_specifier():
     the_node.add("values", scarab.ParamArray())
     the_node["values"].push_back(scarab.ParamValue("a_better_endpoint"))
     a_set_request = dripline.core.MsgRequest.create(the_node, dripline.core.op_t.set, "hey")
-    correct_error = False
-    try:
+    with pytest.raises(dripline.core.ThrowReply) as excinfo:
         a_reply = an_endpoint.do_set_request(a_set_request)
-    except dripline.core.ThrowReply as e:
-        correct_error = True
-    assert(correct_error)
 
 def test_do_set_request_invalid_specifier():
     an_endpoint = dripline.core.Endpoint("an_endpoint")
@@ -96,13 +78,8 @@ def test_do_set_request_invalid_specifier():
     the_node.add("values", scarab.ParamArray())
     the_node["values"].push_back(scarab.ParamValue("a_better_endpoint"))
     a_set_request = dripline.core.MsgRequest.create(the_node, dripline.core.op_t.set, "hey", "namee", "a_receiver")
-    correct_error = False
-    try:
+    with pytest.raises(dripline.core.ThrowReply) as excinfo:
         a_reply = an_endpoint.do_set_request(a_set_request)
-    except dripline.core.ThrowReply as e:
-        correct_error = True
-        print('content of error:\n{}'.format(dir(e)))
-    assert(correct_error)
 
 def test_do_set_request_valid_specifier():
     value1 = "an_endpoint"
@@ -125,14 +102,8 @@ def test_do_set_request_valid_specifier():
 def test_do_cmd_request_invalid_specifier():
     an_endpoint = dripline.core.Endpoint("an_endpoint")
     a_cmd_request = dripline.core.MsgRequest.create(scarab.Param(), dripline.core.op_t.cmd, "hey", "on_gett", "a_receiver")
-    correct_error = False
-    try:
+    with pytest.raises(dripline.core.ThrowReply) as excinfo:
         a_reply = an_endpoint.do_cmd_request(a_cmd_request)
-    except dripline.core.ThrowReply as e:
-        correct_error = True
-    except Exception as e:
-        print("got a [{}]".format(type(e)))
-    assert(correct_error)
 
 def test_do_cmd_request_valid_specifier():
     class AnotherEndpoint(dripline.core.Endpoint):

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -50,6 +50,11 @@ def test_lockout_key_roundtrip():
     lk_rt = a_request.lockout_key  # get the id back
     assert(lk_rt == random_uuid)  # test being able to set and then get the id
 
+    random_uuid_2 = uuid.uuid4()
+    a_request.lockout_key = str(random_uuid_2)  # set the id from a string
+    lk_rt_2 = a_request.lockout_key  # get the id back
+    assert(lk_rt_2 == random_uuid_2)  # test being able to set and then get the id
+
 def test_request_reply_default():
     a_request = _dripline.core.MsgRequest.create(reply_to = "a_receiver")
     a_reply = a_request.reply()


### PR DESCRIPTION
## New Features
Adjusted services and endpoints to be able to return dicts on get requests, and handle bad objects in returns. 
Mixin class for services and interfaces to be able to execute gets, sets, and cmds. 
Mixin class for services and endpoints to be able to respond to gets, sets, and cmds. 

## Fixes

## Testing
Tests conducted on personal machine, using code in `scripts/pkolbeck_scripts/dripline_testing` 
pytest in dripline-python/tests. 
KNOWN ISSUES
A service querying an endpoint that it holds breaks the service somehow via creating new (bad?) channels in the rabbit-broker. 
pytest throws two warnings, but has no errors. 
`2025-04-10 18:48:11.504 [WARNING] (7) endpoint.cc:213 -> Cannot send reply because the service pointer is not set
2025-04-10 18:48:11.506 [WARNING] (7) endpoint.cc:213 -> Cannot send reply because the service pointer is not set
`
unknown if this prevents functionality. 

## Prior to merging for releases:
- [  ] update the project's version in the top-level `CMakeLists.txt` file
- [  ] update the `appVersion` to be the new container image tag version in `chart/Chart.yaml`

