### PR TITLE
fix possible resource leak on PostgreSQL access

### DIFF
--- a/dripline/implementations/postgres_interface.py
+++ b/dripline/implementations/postgres_interface.py
@@ -141,17 +141,17 @@ class SQLTable(Endpoint):
             this_select = this_select.where(getattr(self.table.c,c)<v)
         for c,v in where_gt_dict.items():
             this_select = this_select.where(getattr(self.table.c,c)>v)
-        conn = self.service.engine.connect()
-        result = conn.execute(this_select)
+        with self.service.engine.connect() as conn:
+            result = conn.execute(this_select)
         return (result.keys(), [i for i in result])
 
     def _insert_with_return(self, insert_kv_dict, return_col_names_list):
         ins = self.table.insert().values(**insert_kv_dict)
         if return_col_names_list:
             ins = ins.returning(*[self.table.c[col_name] for col_name in return_col_names_list])
-        conn = self.service.engine.connect()
-        insert_result = conn.execute(ins)
-        conn.commit()
+        with self.service.engine.connect() as conn:
+            insert_result = conn.execute(ins)
+            conn.commit()
         if return_col_names_list:
             return_values = insert_result.first()
         else:


### PR DESCRIPTION
## Fixes
The conn.close() method must be called to avoid resource leakage. This is automatically done when the conn variable is deleted (we should not rely on this, though), and often the conn variable is automatically deleted when returned from the function; however, if an exception happens, all the local variables are capcured by the traceback object and raised to the caller, causing the garbage collector not removing it.

We actually observed resource leakage that led to reliable crashes after 90 min when exceptions are constantly thrown, and the crashing stopped after stopping the exception (writing data before the endpoint entry is made on the name-id map). It is not clear yet why the traceback objects are not deleted on the next exception, but given the observations, doing this good practice (explicit resource management) would be a good thing anyway.

## Testing
I didn't run any test. I did not even run the updated script.

## Prior to merging for releases:
- [ ] update the project's version in the top-level `CMakeLists.txt` file
- [ ] update the `appVersion` to be the new container image tag version in `chart/Chart.yaml`
