### PR TITLE
Restore dl2 FormatEntity default regex

### DIFF
--- a/dripline/implementations/entity_endpoints.py
+++ b/dripline/implementations/entity_endpoints.py
@@ -39,7 +39,7 @@ class SimpleSCPIEntity(Entity):
         '''
         Entity.__init__(self, **kwargs)
         if base_str is None:
-            raise ThrowReply('service_error_invalid_value', '<base_str> is required to __init__ SimpleSCPIEntity instance')
+            raise ValueError('<base_str> is required to __init__ SimpleSCPIEntity instance')
         else:
             self.cmd_base = base_str
 
@@ -105,11 +105,11 @@ class FormatEntity(Entity):
         '''
         Args:
             get_str (str): sent verbatim in the event of on_get; if None, getting of endpoint is disabled
-            get_reply_float (bool): apply special formatting to get return
             set_str (str): sent as set_str.format(value) in the event of on_set; if None, setting of endpoint is disabled
             set_value_lowercase (bool): default option to map all string set value to .lower()
                 **WARNING**: never set to False if using a set_value_map dict
             set_value_map (str||dict): inverse of calibration to map raw set value to value sent; either a dictionary or an asteval-interpretable string
+            get_reply_float (bool): apply special default formatting to get float return
             extract_raw_regex (str): regular expression search pattern applied to get return. Must be constructed with an extraction group keyed with the name "value_raw" (ie r'(?P<value_raw>)' ) 
         '''
         Entity.__init__(self, **kwargs)
@@ -120,10 +120,10 @@ class FormatEntity(Entity):
         self._extract_raw_regex = extract_raw_regex
         self.evaluator = asteval.Interpreter()
         if set_value_map is not None and not isinstance(set_value_map, (dict,str)):
-            raise ThrowReply('service_error_invalid_value', f"Invalid set_value_map config for {self.name}; type is {type(set_value_map)} not dict")
+            raise ValueError(f"Invalid set_value_map config for {self.name}; type is {type(set_value_map)} not dict")
         self._set_value_lowercase = set_value_lowercase
         if isinstance(set_value_map, dict) and not set_value_lowercase:
-            raise ThrowReply('service_error_invalid_value', f"Invalid config option for {self.name} with set_value_map and set_value_lowercase=False")
+            raise ValueError(f"Invalid config option for {self.name} with set_value_map and set_value_lowercase=False")
 
     @calibrate()
     def on_get(self):
@@ -131,7 +131,7 @@ class FormatEntity(Entity):
             # exceptions.DriplineMethodNotSupportedError
             raise ThrowReply('message_error_invalid_method', f"endpoint '{self.name}' does not support get")
         result = self.service.send_to_device([self._get_str])
-        logger.debug(f'result is: {result}')
+        logger.debug(f'raw result is: {result}')
         if self._extract_raw_regex is not None:
             first_result = result
             matches = re.search(self._extract_raw_regex, first_result)
@@ -140,6 +140,9 @@ class FormatEntity(Entity):
                 raise ThrowReply('service_error_invalid_value', 'device returned unparsable result, [{}] has no match to input regex [{}]'.format(first_result, self._extract_raw_regex))
             logger.debug(f"matches are: {matches.groupdict()}")
             result = matches.groupdict()['value_raw']
+        elif self._get_reply_float:
+            result = float(re.findall("[-+]?\d+\.\d+",format(result))[0])
+            logger.debug(f"formatted result is {result}")
         return result
 
     def on_set(self, value):


### PR DESCRIPTION
## New Features
* Restore `get_reply_float` functionality from dl2 (provides default regex for stripping get response down to float)

## Fixes
* Revert error handling in default Entity methods to python standards