### PR TITLE
Fixing entity bugs

### DIFF
--- a/dripline/core/calibrate.py
+++ b/dripline/core/calibrate.py
@@ -49,8 +49,8 @@ def calibrate(cal_functions=None):
                     val_dict['value_cal'] = cal
             elif isinstance(self._calibration, dict):
                 logger.debug('calibration is dictionary, looking up value')
-                if val_dict['value_raw'] in self._calibration:
-                    val_dict['value_cal'] = self._calibration[val_dict['value_raw']]
+                if str(val_dict['value_raw']) in self._calibration:
+                    val_dict['value_cal'] = self._calibration[str(val_dict['value_raw'])]
                 else:
                     raise ThrowReply('service_error_invalid_value', f"raw value <{repr(val_dict['value_raw'])}> not in cal dict")
             else:

--- a/dripline/core/entity.py
+++ b/dripline/core/entity.py
@@ -176,8 +176,12 @@ class Entity(Endpoint):
             raise ThrowReply('service_error_invalid_value', f"unable to interpret a new_interval of type <{type(new_interval)}>")
 
     def scheduled_log(self):
-        logger.debug("in a scheduled log event")
-        result = self.on_get()
+        logger.debug(f"in a scheduled log event for {self.name}")
+        try:
+            result = self.on_get()
+        except ThrowReply as err:
+            logger.warning(f'scheduled log failed with error:\n{err}')
+            return
         try:
             this_value = float(result[self._check_field])
             is_float = True


### PR DESCRIPTION
## Fixes
* scheduled_log now performs on_get in try/except loop to catch dripline errors and not crash, instead throwing a warning and returning
* calibrate now forces dict calibrations to be mapped to string, reflecting how scarab reads and passes calibration information

## Testing
* tested with a few example services to ensure it works at small scale

## Prior to merging for releases:
- [ ] update the project's version in the top-level `CMakeLists.txt` file
- [ ] update the `appVersion` to be the new container image tag version in `chart/Chart.yaml`
